### PR TITLE
fix: 액세스 토큰 사라진 후 재로그인 시 MY탭에서 로그인 페이지가 보이는 문제 수정

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.codeActionsOnSave": {
-      "source.fixAll": true
-    }
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
   }
+}

--- a/src/components/spec-analysis/AIInsights.jsx
+++ b/src/components/spec-analysis/AIInsights.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Sparkles, TrendingUp } from 'lucide-react';
+
+const AIInsights = () => {
+  const insights = [
+    {
+      id: 1,
+      text: '활동 점수(85점)가 우수하니 이를 활용한 네트워킹 확대를 추천합니다.',
+      icon: TrendingUp,
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center space-x-2 mb-4">
+        <div className="w-6 h-6 bg-gradient-to-r from-blue-500 to-purple-600 rounded-full flex items-center justify-center">
+          <Sparkles size={12} className="text-white" />
+        </div>
+        <h4 className="font-bold text-gray-800">AI 맞춤 개선방안</h4>
+      </div>
+
+      {insights.map((insight, index) => {
+        const IconComponent = insight.icon;
+        return (
+          <div
+            key={insight.id}
+            className="bg-gradient-to-r from-blue-50 to-purple-50 rounded-lg p-4 border border-blue-100 opacity-0 animate-fade-in"
+            style={{
+              animationDelay: `${index * 0.2}s`,
+              animationFillMode: 'forwards',
+            }}
+          >
+            <div className="flex items-start space-x-3">
+              <div
+                className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${
+                  insight.priority === 'high'
+                    ? 'bg-red-100 text-red-600'
+                    : 'bg-blue-100 text-blue-600'
+                }`}
+              >
+                <IconComponent size={14} />
+              </div>
+              <div className="flex-1">
+                <p className="text-sm text-gray-700 leading-relaxed">
+                  {insight.text}
+                </p>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+
+      <style jsx>{`
+        @keyframes fade-in {
+          from {
+            opacity: 0;
+            transform: translateY(10px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+        .animate-fade-in {
+          animation: fade-in 0.6s ease-out;
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default AIInsights;

--- a/src/components/spec-analysis/SpecBars.jsx
+++ b/src/components/spec-analysis/SpecBars.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { GraduationCap, Briefcase, Award, BookOpen, Users } from 'lucide-react';
+
+const SpecBars = ({ animatedScores, aiTitle, aiIcon }) => {
+  const specData = [
+    { category: '학력', icon: GraduationCap, colorHex: '#3b82f6' },
+    { category: '경험', icon: Briefcase, colorHex: '#8b5cf6' },
+    { category: '자격증', icon: Award, colorHex: '#10b981' },
+    { category: '어학', icon: BookOpen, colorHex: '#f59e0b' },
+    { category: '활동', icon: Users, colorHex: '#ef4444' },
+  ];
+
+  return (
+    <div className="space-y-3">
+      {/* AI 타이틀/아이콘 줄 */}
+      {aiTitle && (
+        <div className="flex items-center space-x-3 mb-4">
+          <div className="w-8 h-8 bg-gradient-to-r from-blue-500 to-purple-600 rounded-xl flex items-center justify-center">
+            {aiIcon}
+          </div>
+          <h4 className="font-bold bg-gradient-to-r from-blue-600 to-purple-600 text-transparent bg-clip-text">
+            {aiTitle}
+          </h4>
+        </div>
+      )}
+      {specData.map((item, index) => {
+        const IconComponent = item.icon;
+        return (
+          <div
+            key={index}
+            className="flex items-center space-x-3 opacity-0 animate-slide-up"
+            style={{
+              animationDelay: `${index * 0.1}s`,
+              animationFillMode: 'forwards',
+            }}
+          >
+            <IconComponent size={16} style={{ color: item.colorHex }} />
+            <div className="w-12 text-xs font-medium text-gray-600">
+              {item.category}
+            </div>
+            <div className="flex-1 bg-gray-200 rounded-full h-2">
+              <div
+                className="h-2 rounded-full"
+                style={{
+                  width: `${animatedScores[index]}%`,
+                  backgroundColor: item.colorHex,
+                }}
+              />
+            </div>
+            <div
+              className="w-8 text-xs font-bold"
+              style={{ color: item.colorHex }}
+            >
+              {animatedScores[index]}
+            </div>
+          </div>
+        );
+      })}
+
+      <style jsx>{`
+        @keyframes slide-up {
+          from {
+            opacity: 0;
+            transform: translateY(10px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+        .animate-slide-up {
+          animation: slide-up 0.5s ease-out;
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default SpecBars;

--- a/src/components/user/UserInfoSection.jsx
+++ b/src/components/user/UserInfoSection.jsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from 'react';
+import { Brain } from 'lucide-react';
+import HomeProfileCard from './profile/HomeProfileCard';
+import SpecBars from '../spec-analysis/SpecBars';
+import AIInsights from '../spec-analysis/AIInsights';
+
+const UserInfoSection = ({
+  userData,
+  isLoggedIn = false,
+  hasSpec = false,
+  categoryScores = [],
+}) => {
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const [animatedScores, setAnimatedScores] = useState([0, 0, 0, 0, 0]);
+  const [showBars, setShowBars] = useState(false);
+  const [showInsights, setShowInsights] = useState(false);
+
+  // 애니메이션 효과
+  useEffect(() => {
+    if (isLoggedIn && hasSpec && userData && categoryScores.length > 0) {
+      setIsAnalyzing(true);
+      setShowBars(true);
+      setShowInsights(true);
+      setAnimatedScores([0, 0, 0, 0, 0]);
+
+      // 스펙 분석 애니메이션
+      const animateScores = () => {
+        const duration = 2000;
+        const steps = 60;
+        const stepDuration = duration / steps;
+
+        for (let i = 0; i <= steps; i++) {
+          setTimeout(() => {
+            const progress = i / steps;
+            const easeOut = 1 - Math.pow(1 - progress, 3);
+            setAnimatedScores(
+              categoryScores.map((score) => Math.floor(score * easeOut))
+            );
+
+            if (i === steps) {
+              setIsAnalyzing(false);
+              // 막대 그래프 표시
+              setTimeout(() => {
+                setShowBars(true);
+                setTimeout(() => setShowInsights(true), 800);
+              }, 200);
+            }
+          }, i * stepDuration);
+        }
+      };
+
+      const timer = setTimeout(animateScores, 100);
+      return () => clearTimeout(timer);
+    } else {
+      // 스펙이 없거나 로그인하지 않은 경우 애니메이션 상태 초기화
+      setShowBars(false);
+      setShowInsights(false);
+      setAnimatedScores([0, 0, 0, 0, 0]);
+    }
+  }, [isLoggedIn, hasSpec, userData, categoryScores]);
+
+  // 스펙이 없거나 로그인하지 않은 경우 기본 프로필 카드만 표시
+  if (!isLoggedIn || !hasSpec || categoryScores.length === 0) {
+    return (
+      <HomeProfileCard
+        userData={userData}
+        isLoggedIn={isLoggedIn}
+        hasSpec={hasSpec}
+      />
+    );
+  }
+
+  // 로그인하고 스펙이 있는 경우 AI 분석 포함
+  return (
+    <div className="w-full mb-4 bg-white rounded-2xl shadow-sm border border-gray-100">
+      <div className="p-4">
+        <HomeProfileCard
+          userData={userData}
+          isLoggedIn={isLoggedIn}
+          hasSpec={hasSpec}
+        />
+      </div>
+
+      <div className="p-5 border-t border-gray-200">
+        <SpecBars
+          animatedScores={animatedScores}
+          aiTitle="AI 기반 스펙 분석"
+          aiIcon={<Brain size={15} className="text-white" />}
+        />
+
+        {showInsights && (
+          <div className="mt-6 pt-4 border-t border-gray-200">
+            <AIInsights />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default UserInfoSection;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { SpecAPI, UserAPI } from '../api';
 import { useAuthStore } from '../stores/useAuthStore';
-import HomeProfileCard from '../components/user/profile/HomeProfileCard';
+import UserInfoSection from '../components/user/UserInfoSection';
 import ServiceIntro from '../components/ServiceIntro';
 import RankingFilters from '../components/ranking/RankingFilters';
 import RankingItem from '../components/ranking/RankingItem';
@@ -18,6 +18,7 @@ const HomePage = () => {
 
   const [userData, setUserData] = useState(null);
   const [hasSpec, setHasSpec] = useState(false);
+  const [categoryScores, setCategoryScores] = useState([]);
   const [profileLoading, setProfileLoading] = useState(true);
 
   const fetchUserProfile = useCallback(async () => {
@@ -56,6 +57,21 @@ const HomePage = () => {
             if (specResponse.data.isSuccess) {
               const specData = specResponse.data.specDetailData;
               const rankings = specData.rankings?.details;
+              const categories = specData.rankings?.categories || [];
+
+              const scores = [
+                categories.find((category) => category.name === '학력_성적')
+                  ?.score || 0,
+                categories.find((category) => category.name === '직무_경험')
+                  ?.score || 0,
+                categories.find((category) => category.name === '자격증_스킬')
+                  ?.score || 0,
+                categories.find((category) => category.name === '어학_능력')
+                  ?.score || 0,
+                categories.find((category) => category.name === '활동_네트워킹')
+                  ?.score || 0,
+              ];
+              setCategoryScores(scores);
 
               if (rankings) {
                 // 상위 퍼센트 계산
@@ -163,10 +179,11 @@ const HomePage = () => {
 
   return (
     <div className="p-4">
-      <HomeProfileCard
+      <UserInfoSection
         userData={userData}
         isLoggedIn={isLoggedIn}
         hasSpec={hasSpec}
+        categoryScores={categoryScores}
       />
 
       <ServiceIntro />

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,22 +1,43 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getCookie } from '../utils/cookie';
+import { useAuthStore } from '../stores/useAuthStore';
 
 const LoginPage = () => {
   const navigate = useNavigate();
+  const { isLoggedIn, loading } = useAuthStore();
   const [showRedirectNotice, setShowRedirectNotice] = useState(false);
+
+  // 이미 로그인된 경우 홈페이지로 리다이렉트
+  useEffect(() => {
+    if (!loading && isLoggedIn) {
+      console.log('이미 로그인된 상태, 홈페이지로 이동');
+      navigate('/', { replace: true });
+    }
+  }, [isLoggedIn, loading, navigate]);
 
   // 쿠키에서 TempLoginId 확인
   useEffect(() => {
-    const tempLoginId = getCookie("TempLoginId");
-  
+    if (loading) return;
+
+    const tempLoginId = getCookie('TempLoginId');
+
     if (tempLoginId) {
       setShowRedirectNotice(true);
       setTimeout(() => {
         navigate('/profile-setup');
       }, 1500);
     }
-  }, [navigate]);
+  }, [navigate, loading]);
+
+  // 로딩 중이면 로딩 화면 표시
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-gray-500">로딩 중...</div>
+      </div>
+    );
+  }
 
   // 리다이렉션 안내 문구
   if (showRedirectNotice) {
@@ -24,9 +45,13 @@ const LoginPage = () => {
       <div className="flex items-center justify-center min-h-screen p-4">
         <div className="p-6 bg-white rounded shadow-md">
           <p className="font-medium text-gray-800">
-            소셜 인증은 완료되었으나<br/>회원가입이 필요합니다.
+            소셜 인증은 완료되었으나
+            <br />
+            회원가입이 필요합니다.
           </p>
-          <p className="mt-2 text-sm text-gray-500">회원가입 페이지로 이동 중...</p>
+          <p className="mt-2 text-sm text-gray-500">
+            회원가입 페이지로 이동 중...
+          </p>
         </div>
       </div>
     );
@@ -42,33 +67,40 @@ const LoginPage = () => {
   };
 
   return (
-      <div className="flex flex-col items-center justify-center p-4">
-        <div className="w-full max-w-md p-8 my-8 space-y-8 bg-white rounded-lg shadow">
-          <div className="text-center">
-            <div className="flex justify-center mb-2">
-              <div className="flex items-center justify-center w-16 h-16 bg-indigo-100 rounded-full">
-                <img src='/specranking_logo.png' alt='logo'/>
-              </div>
+    <div className="flex flex-col items-center justify-center p-4">
+      <div className="w-full max-w-md p-8 my-8 space-y-8 bg-white rounded-lg shadow">
+        <div className="text-center">
+          <div className="flex justify-center mb-2">
+            <div className="flex items-center justify-center w-16 h-16 bg-indigo-100 rounded-full">
+              <img src="/specranking_logo.png" alt="logo" />
             </div>
-            
-            <h2 className="text-xl font-semibold text-indigo-900">스펙랭킹</h2>
-            <p className="mt-2 text-sm font-semibold text-gray-500">
-              취업 준비의 모든 것,<br/>당신의 커리어를 한 단계 더 높이세요
-            </p>
           </div>
-          
-          <div className="mt-10">
-            <button onClick={handleLogin}>
-              <img src='/kakao_login_large_wide.png' alt='카카오 계정으로 로그인'/>
-            </button>
-            
-            <p className="mt-5 text-xs text-center text-gray-600">
-              아직 회원이 아니신가요?<br/>로그인 시 자동 회원가입됩니다.
-            </p>
-          </div>
+
+          <h2 className="text-xl font-semibold text-indigo-900">스펙랭킹</h2>
+          <p className="mt-2 text-sm font-semibold text-gray-500">
+            취업 준비의 모든 것,
+            <br />
+            당신의 커리어를 한 단계 더 높이세요
+          </p>
+        </div>
+
+        <div className="mt-10">
+          <button onClick={handleLogin}>
+            <img
+              src="/kakao_login_large_wide.png"
+              alt="카카오 계정으로 로그인"
+            />
+          </button>
+
+          <p className="mt-5 text-xs text-center text-gray-600">
+            아직 회원이 아니신가요?
+            <br />
+            로그인 시 자동 회원가입됩니다.
+          </p>
         </div>
       </div>
-    );
+    </div>
+  );
 };
 
 export default LoginPage;

--- a/src/pages/OAuthRedirectPage.jsx
+++ b/src/pages/OAuthRedirectPage.jsx
@@ -1,37 +1,36 @@
-import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
-import { useAuthStore } from "../stores/useAuthStore";
-import { getCookie, deleteCookie } from "../utils/cookie";
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '../stores/useAuthStore';
+import { getCookie, deleteCookie } from '../utils/cookie';
 
 const OAuthRedirectPage = () => {
-    const navigate = useNavigate();
-    const { login } = useAuthStore();
+  const navigate = useNavigate();
+  const { login } = useAuthStore();
 
-    useEffect(() => {
-        const tempLoginId = getCookie('TempLoginId');
-        const authorization = getCookie('access');
+  useEffect(() => {
+    const tempLoginId = getCookie('TempLoginId');
+    const authorization = getCookie('access');
 
-        if (tempLoginId) {
-            navigate('/profile-setup');
-            return;
-        } 
-        if (authorization) {
-            login(null, authorization);
-            deleteCookie('access');
-            navigate('/');
-            return;
-        }
+    if (tempLoginId) {
+      navigate('/profile-setup');
+      return;
+    }
+    if (authorization) {
+      login(null, authorization);
+      deleteCookie('access');
+      window.location.href = '/';
+      return;
+    }
 
-        console.log('로그인 실패: Authorization, TempLoginId 둘 다 존재 X');
-        navigate('/login');
-        
-    }, [navigate, login]);
+    console.log('로그인 실패: Authorization, TempLoginId 둘 다 존재 X');
+    navigate('/login');
+  }, [navigate, login]);
 
-    return (
-        <div className="flex items-center justify-center min-h-screen">
-            <p className="text-gray-600">처리 중입니다...</p>
-        </div>
-    );
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <p className="text-gray-600">처리 중입니다...</p>
+    </div>
+  );
 };
 
 export default OAuthRedirectPage;


### PR DESCRIPTION
## ☝️ 요약
액세스 토큰 사라진 후 재로그인 시 MY탭에서 로그인 페이지가 보이는 문제 수정

<br/>

## ✏️ 상세 내용
- 페이지에 접속한 상태에서 오랜 시간 아무 작업도 하지 않으면 액세스 토큰이 재발급되지 않아 액세스 토큰은 사라지고 리프레시 토큰만 남음
- 작업을 하려면 로그인을 다시 해야 하는데 로그인 성공 시 하단메뉴바가 LOGIN에서 MY로 변경되지만 페이지 내용은 여전히 로그인 페이지 내용이 나타남
- 다른 메뉴에 갔다오면 페이지 내용이 정상적으로 바뀜
- 인증 상태 관련 문제인 것으로 추정되어 LoginPage.jsx, OAuthRedirectPage.jsx 수정하여 문제 해결함

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [x] Assignee를 지정했습니다.
- [ ] Reviewer를 지정했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)