### PR TITLE
feat: 댓글 기능 api 연동 완료

### DIFF
--- a/src/api/comment.js
+++ b/src/api/comment.js
@@ -1,0 +1,32 @@
+import http from './http';
+
+export const getComments = (specId, { page = 0, size = 10 } = {}) => {
+  return http.get(`/api/specs/${specId}/comments`, {
+    params: {
+      page,
+      size,
+    },
+  });
+};
+
+export const createComment = (specId, content) => {
+  return http.post(`/api/specs/${specId}/comments`, {
+    content,
+  });
+};
+
+export const createReply = (specId, commentId, content) => {
+  return http.post(`/api/specs/${specId}/comments/${commentId}/replies`, {
+    content,
+  });
+};
+
+export const updateComment = (specId, commentId, content) => {
+  return http.patch(`/api/specs/${specId}/comments/${commentId}`, {
+    content,
+  });
+};
+
+export const deleteComment = (specId, commentId) => {
+  return http.delete(`/api/specs/${specId}/comments/${commentId}`);
+};

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -5,3 +5,4 @@ export * as SpecAPI from './spec';
 export * as BookmarkAPI from './bookmark';
 export * as ChatAPI from './chat';
 export * as NotificationAPI from './notification';
+export * as CommentAPI from './comment';

--- a/src/components/comment/CommentItem.jsx
+++ b/src/components/comment/CommentItem.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Pencil,
   Trash2,
@@ -11,11 +11,19 @@ import Modal from '../common/Modal';
 const CommentItem = ({ comment, currentUser, onEdit, onDelete, onReply }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [isReplying, setIsReplying] = useState(false);
-  const [editText, setEditText] = useState(comment.content);
+  const [editText, setEditText] = useState('');
   const [replyText, setReplyText] = useState('');
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [editingReplyId, setEditingReplyId] = useState(null);
+  const [editingReplyText, setEditingReplyText] = useState('');
+  const [deletingReplyId, setDeletingReplyId] = useState(null);
+
+  useEffect(() => {
+    setEditText(comment.content);
+  }, [comment.content]);
 
   const isMyComment = comment.userId === currentUser?.id;
+  const isDeletedComment = comment.content === '삭제된 댓글입니다.';
 
   const handleEditSubmit = () => {
     if (editText.trim()) {
@@ -52,11 +60,42 @@ const CommentItem = ({ comment, currentUser, onEdit, onDelete, onReply }) => {
     }
   };
 
+  const handleReplyEdit = (replyId, replyContent) => {
+    setEditingReplyId(replyId);
+    setEditingReplyText(replyContent);
+  };
+
+  const handleReplyEditSubmit = (replyId) => {
+    if (editingReplyText.trim()) {
+      onEdit(replyId, editingReplyText);
+      setEditingReplyId(null);
+      setEditingReplyText('');
+    }
+  };
+
+  const handleReplyEditCancel = () => {
+    setEditingReplyId(null);
+    setEditingReplyText('');
+  };
+
+  const handleReplyDelete = (replyId) => {
+    setDeletingReplyId(replyId);
+  };
+
+  const handleReplyDeleteConfirm = () => {
+    onDelete(deletingReplyId);
+    setDeletingReplyId(null);
+  };
+
+  const handleReplyDeleteCancel = () => {
+    setDeletingReplyId(null);
+  };
+
   return (
     <div className="py-4 border-b border-gray-100 last:border-b-0">
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center space-x-2">
-          <div className="w-6 h-6 rounded-full overflow-hidden bg-gradient-to-br from-blue-400 to-indigo-500 flex items-center justify-center text-white text-xs font-bold flex-shrink-0">
+          <div className="w-5 h-5 rounded-full overflow-hidden bg-gradient-to-br from-blue-400 to-indigo-500 flex items-center justify-center text-white text-xs font-bold flex-shrink-0">
             {comment.profileImageUrl ? (
               <img
                 src={comment.profileImageUrl}
@@ -64,16 +103,27 @@ const CommentItem = ({ comment, currentUser, onEdit, onDelete, onReply }) => {
                 className="w-full h-full object-cover"
               />
             ) : (
-              comment.nickname?.charAt(0) || '?'
+              '?'
             )}
           </div>
-          <span className="font-bold text-gray-800">{comment.nickname}</span>
-          <span className="text-xs text-gray-500">{comment.createdAt}</span>
+          <span className="text-sm font-bold text-gray-800">
+            {comment.nickname}
+          </span>
+          <span className="text-xs text-gray-500">
+            {comment.updatedAt !== comment.createdAt ? (
+              <>
+                {comment.updatedAt}{' '}
+                <span className="text-gray-400">(수정됨)</span>
+              </>
+            ) : (
+              comment.createdAt
+            )}
+          </span>
         </div>
 
         {/* 수정/삭제/답글 버튼 */}
         <div className="flex items-center space-x-1">
-          {isMyComment && (
+          {isMyComment && !isDeletedComment && (
             <>
               <button
                 onClick={() => setIsEditing(!isEditing)}
@@ -89,16 +139,18 @@ const CommentItem = ({ comment, currentUser, onEdit, onDelete, onReply }) => {
               </button>
             </>
           )}
-          <button
-            onClick={() => setIsReplying(!isReplying)}
-            className="text-gray-400 hover:text-gray-600 transition-colors p-1"
-          >
-            <Reply size={12} />
-          </button>
+          {!isDeletedComment && (
+            <button
+              onClick={() => setIsReplying(!isReplying)}
+              className="text-gray-400 hover:text-gray-600 transition-colors p-1"
+            >
+              <Reply size={12} />
+            </button>
+          )}
         </div>
       </div>
 
-      {isEditing ? (
+      {isEditing && !isDeletedComment ? (
         <div className="mb-3">
           <textarea
             value={editText}
@@ -133,10 +185,12 @@ const CommentItem = ({ comment, currentUser, onEdit, onDelete, onReply }) => {
           </div>
         </div>
       ) : (
-        <p className="text-gray-700 leading-relaxed">{comment.content}</p>
+        <p className="text-sm text-gray-700 leading-relaxed">
+          {comment.content}
+        </p>
       )}
 
-      {isReplying && (
+      {isReplying && !isDeletedComment && (
         <div className="mt-3 ml-6">
           <div className="flex items-start space-x-2">
             <CornerDownRight
@@ -160,7 +214,7 @@ const CommentItem = ({ comment, currentUser, onEdit, onDelete, onReply }) => {
               />
               <div className="flex justify-between items-center mt-1">
                 <span className="text-xs text-gray-500">
-                  {editText.length}/100
+                  {replyText.length}/100
                 </span>
               </div>
               <div className="flex justify-end space-x-2 mt-2">
@@ -183,23 +237,113 @@ const CommentItem = ({ comment, currentUser, onEdit, onDelete, onReply }) => {
       )}
 
       {comment.replies && comment.replies.length > 0 && (
-        <div className="mt-4 ml-6 space-y-3">
+        <div className="mt-4 ml-1 space-y-3">
           {comment.replies.map((reply) => (
             <div key={reply.id} className="flex items-start space-x-2">
               <CornerDownRight
                 size={16}
                 className="text-gray-400 mt-1 flex-shrink-0"
               />
-              <div className="flex-1">
-                <div className="flex items-center space-x-2 mb-1">
-                  <span className="font-medium text-gray-700">
-                    {reply.nickname}
-                  </span>
-                  <span className="text-xs text-gray-500">
-                    {reply.createdAt}
-                  </span>
+              <div className="flex-1 py-2">
+                <div className="flex items-center justify-between mb-2">
+                  <div className="flex items-center space-x-2">
+                    <div className="w-5 h-5 rounded-full overflow-hidden bg-gradient-to-br from-blue-400 to-indigo-500 flex items-center justify-center text-white text-xs font-bold flex-shrink-0">
+                      {reply.profileImageUrl ? (
+                        <img
+                          src={reply.profileImageUrl}
+                          alt={reply.nickname}
+                          className="w-full h-full object-cover"
+                        />
+                      ) : (
+                        '?'
+                      )}
+                    </div>
+                    <span className="text-sm font-bold text-gray-800">
+                      {reply.nickname}
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      {reply.updatedAt &&
+                      reply.updatedAt !== reply.createdAt ? (
+                        <>
+                          {reply.updatedAt}{' '}
+                          <span className="text-gray-400">(수정됨)</span>
+                        </>
+                      ) : (
+                        reply.createdAt
+                      )}
+                    </span>
+                  </div>
+
+                  {/* 대댓글 수정/삭제 버튼 */}
+                  <div className="flex items-center space-x-1">
+                    {reply.userId === currentUser?.id && (
+                      <>
+                        <button
+                          onClick={() =>
+                            handleReplyEdit(reply.id, reply.content)
+                          }
+                          className="text-gray-400 hover:text-blue-500 transition-colors p-1"
+                        >
+                          <Pencil size={12} />
+                        </button>
+                        <button
+                          onClick={() => handleReplyDelete(reply.id)}
+                          className="text-gray-400 hover:text-red-500 transition-colors p-1"
+                        >
+                          <Trash2 size={12} />
+                        </button>
+                      </>
+                    )}
+                  </div>
                 </div>
-                <p className="text-gray-600 text-sm">{reply.content}</p>
+
+                {/* 대댓글 수정 모드 */}
+                {editingReplyId === reply.id ? (
+                  <div className="mb-3">
+                    <textarea
+                      value={editingReplyText}
+                      onChange={(e) => {
+                        if (e.target.value.length <= 100) {
+                          setEditingReplyText(e.target.value);
+                        }
+                      }}
+                      onKeyPress={(e) =>
+                        handleKeyPress(e, () => handleReplyEditSubmit(reply.id))
+                      }
+                      className="w-full p-3 border border-blue-300 rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      rows="1"
+                      placeholder="대댓글을 수정하세요."
+                      maxLength={100}
+                      style={{
+                        scrollbarWidth: 'none',
+                        msOverflowStyle: 'none',
+                      }}
+                    />
+                    <div className="flex justify-between items-center mt-1">
+                      <span className="text-xs text-gray-500">
+                        {editingReplyText.length}/100
+                      </span>
+                    </div>
+                    <div className="flex justify-end space-x-2 mt-2">
+                      <button
+                        onClick={handleReplyEditCancel}
+                        className="px-3 py-1 text-sm border border-gray-400 text-gray-600 rounded hover:border-gray-600 hover:text-gray-800"
+                      >
+                        취소
+                      </button>
+                      <button
+                        onClick={() => handleReplyEditSubmit(reply.id)}
+                        className="px-3 py-1 text-sm bg-blue-500 text-white rounded hover:bg-blue-600"
+                      >
+                        수정
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-gray-600 text-sm leading-relaxed">
+                    {reply.content}
+                  </p>
+                )}
               </div>
             </div>
           ))}
@@ -216,6 +360,20 @@ const CommentItem = ({ comment, currentUser, onEdit, onDelete, onReply }) => {
         secondaryButtonText="아니오"
         onPrimaryButtonClick={handleDeleteConfirm}
         onSecondaryButtonClick={handleDeleteCancel}
+        primaryButtonColor="red"
+      />
+
+      {/* 대댓글 삭제 확인 모달 */}
+      <Modal
+        isOpen={deletingReplyId !== null}
+        onClose={handleReplyDeleteCancel}
+        title="정말 삭제하시겠습니까?"
+        icon={AlertTriangle}
+        iconColor="red"
+        primaryButtonText="예, 삭제합니다"
+        secondaryButtonText="아니오"
+        onPrimaryButtonClick={handleReplyDeleteConfirm}
+        onSecondaryButtonClick={handleReplyDeleteCancel}
         primaryButtonColor="red"
       />
     </div>

--- a/src/components/comment/Pagination.jsx
+++ b/src/components/comment/Pagination.jsx
@@ -18,16 +18,9 @@ const Pagination = ({ currentPage, totalPages, onPageChange }) => {
       }
     } else {
       // 현재 페이지 기준으로 앞뒤 2개씩 표시
-      let startPage = Math.max(1, currentPage - 2);
-      let endPage = Math.min(totalPages, currentPage + 2);
-
-      // 시작이나 끝에 가까우면 조정
-      if (currentPage <= 3) {
-        endPage = 5;
-      }
-      if (currentPage >= totalPages - 2) {
-        startPage = totalPages - 4;
-      }
+      const currentGroup = Math.ceil(currentPage / maxVisiblePages);
+      let startPage = (currentGroup - 1) * maxVisiblePages + 1;
+      let endPage = Math.min(startPage + maxVisiblePages - 1, totalPages);
 
       for (let i = startPage; i <= endPage; i++) {
         pages.push(i);
@@ -38,6 +31,8 @@ const Pagination = ({ currentPage, totalPages, onPageChange }) => {
   };
 
   const visiblePages = getVisiblePages();
+  const currentGroup = Math.ceil(currentPage / 5);
+  const totalGroups = Math.ceil(totalPages / 5);
 
   return (
     <div className="flex items-center justify-center space-x-1 py-3">
@@ -45,23 +40,23 @@ const Pagination = ({ currentPage, totalPages, onPageChange }) => {
       <button
         onClick={() => onPageChange(1)}
         disabled={currentPage === 1}
-        className={`p-1 rounded-md border text-xs ${
+        className={`p-1 text-xs ${
           currentPage === 1
-            ? 'text-gray-300 border-gray-200 cursor-not-allowed'
-            : 'text-gray-600 border-gray-300 hover:bg-gray-50 hover:border-gray-400'
+            ? 'text-gray-300 cursor-not-allowed'
+            : 'text-gray-600 hover:text-gray-400'
         } transition-colors`}
       >
         <ChevronsLeft size={12} />
       </button>
 
-      {/* 이전 페이지 */}
+      {/* 이전 그룹으로 */}
       <button
-        onClick={() => onPageChange(currentPage - 1)}
-        disabled={currentPage === 1}
-        className={`p-1 rounded-md border text-xs ${
-          currentPage === 1
-            ? 'text-gray-300 border-gray-200 cursor-not-allowed'
-            : 'text-gray-600 border-gray-300 hover:bg-gray-50 hover:border-gray-400'
+        onClick={() => onPageChange((currentGroup - 2) * 5 + 1)}
+        disabled={currentGroup === 1}
+        className={`p-1 text-xs ${
+          currentGroup === 1
+            ? 'text-gray-300 cursor-not-allowed'
+            : 'text-gray-600 hover:text-gray-400'
         } transition-colors`}
       >
         <ChevronLeft size={12} />
@@ -72,24 +67,24 @@ const Pagination = ({ currentPage, totalPages, onPageChange }) => {
         <button
           key={page}
           onClick={() => onPageChange(page)}
-          className={`min-w-[28px] h-7 px-2 rounded-md border text-sm font-medium transition-colors ${
+          className={`min-w-[28px] h-7 px-2 text-sm font-medium transition-colors ${
             currentPage === page
-              ? 'bg-blue-500 text-white border-blue-500'
-              : 'text-gray-700 border-gray-300 hover:bg-gray-50 hover:border-gray-400'
+              ? 'text-blue-500'
+              : 'text-gray-700 hover:text-gray-500'
           }`}
         >
           {page}
         </button>
       ))}
 
-      {/* 다음 페이지 */}
+      {/* 다음 그룹으로 */}
       <button
-        onClick={() => onPageChange(currentPage + 1)}
-        disabled={currentPage === totalPages}
-        className={`p-1 rounded-md border text-xs ${
-          currentPage === totalPages
-            ? 'text-gray-300 border-gray-200 cursor-not-allowed'
-            : 'text-gray-600 border-gray-300 hover:bg-gray-50 hover:border-gray-400'
+        onClick={() => onPageChange(currentGroup * 5 + 1)}
+        disabled={currentGroup === totalGroups}
+        className={`p-1 text-xs ${
+          currentGroup === totalGroups
+            ? 'text-gray-300 cursor-not-allowed'
+            : 'text-gray-600 hover:text-gray-400'
         } transition-colors`}
       >
         <ChevronRight size={12} />
@@ -99,10 +94,10 @@ const Pagination = ({ currentPage, totalPages, onPageChange }) => {
       <button
         onClick={() => onPageChange(totalPages)}
         disabled={currentPage === totalPages}
-        className={`p-1 rounded-md border text-xs ${
+        className={`p-1 text-xs ${
           currentPage === totalPages
-            ? 'text-gray-300 border-gray-200 cursor-not-allowed'
-            : 'text-gray-600 border-gray-300 hover:bg-gray-50 hover:border-gray-400'
+            ? 'text-gray-300 cursor-not-allowed'
+            : 'text-gray-600 hover:text-gray-400'
         } transition-colors`}
       >
         <ChevronsRight size={12} />

--- a/src/pages/SocialPage.jsx
+++ b/src/pages/SocialPage.jsx
@@ -21,6 +21,7 @@ const SocialPage = () => {
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [animatedScores, setAnimatedScores] = useState([0, 0, 0, 0, 0]);
   const [activeTab, setActiveTab] = useState('analysis');
+  const [currentSpecId, setCurrentSpecId] = useState(null);
 
   // 실제 스펙 점수 (임시 데이터)
   const actualScores = [50, 0, 60, 75, 85];
@@ -104,12 +105,14 @@ const SocialPage = () => {
           setHasSpec(hasActiveSpec);
 
           if (hasActiveSpec && userInfo.spec?.activeSpec) {
+            setCurrentSpecId(userInfo.spec.activeSpec);
+
             // 스펙이 있는 경우 상세 스펙 정보 조회
             try {
               const specResponse = await SpecAPI.getSpecDetail(
                 userInfo.spec.activeSpec
               );
-              console.log('specResponse: ', specResponse);
+              // console.log('specResponse: ', specResponse);
 
               if (specResponse.data.isSuccess) {
                 const specDetailData = specResponse.data.specDetailData;
@@ -141,12 +144,15 @@ const SocialPage = () => {
             } catch (specError) {
               console.error('스펙 정보 조회 실패:', specError);
             }
+          } else {
+            setCurrentSpecId(null);
           }
 
           setUserData(profileData);
         }
       } else {
         setIsMyPage(false);
+        setCurrentSpecId(specId);
 
         // const userResponse = await mockAPI.getUserBySpecId(specId);
         const userResponse = await UserAPI.getUserInfo(specId);
@@ -292,8 +298,9 @@ const SocialPage = () => {
         </div>
 
         <CommentsSection
-          specId={specId || userData.spec?.activeSpec}
+          specId={currentSpecId}
           isMyPage={isMyPage}
+          currentUser={currentUser}
         />
       </div>
     </div>


### PR DESCRIPTION
## ☝️ 요약
댓글 기능 api 연동 완료

<br/>

## ✏️ 상세 내용
- 댓글.대댓글 목록 조회
- 댓글 작성 / 대댓글 작성
- 댓글 수정 / 대댓글 수정
- 댓글 삭제 / 대댓글 삭제
- 댓글.대댓글 삭제 처리
    - 대댓글은 바로 삭제됨
    - 대댓글이 없는 댓글은 바로 삭제됨
    - 대댓글이 달린 댓글은 삭제 시 닉네임과 댓글 내용이 마스킹된 채로 남아있음
- 댓글 페이지 네비게이션바 페이지 넘어가는 방식 수정
    - 현재 페이지를 중앙에 두는 방식이었는데 고정 그룹 방식으로 수정함
    - ex) 4페이지 클릭 시 '2 3 4 5 6'으로 바뀌던 방식 -> '1 2 3 4 5'를 그대로 유지하는 방식으로 수정함

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.
- [x] 로컬에서 위에 적힌 기능들에 대해 모두 테스트 완료하였습니다.
- [x] db에서 데이터가 잘 처리되는지 확인했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)