### PR TITLE
feat: 상세보기 버튼 기능 구현, 즐겨찾기 버튼 상태 동기화

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -78,7 +78,7 @@ const Layout = ({ children }) => {
         return '랭킹';
       case '/ranking-results':
         return '랭킹 검색 결과';
-      case '/social':
+      case '/dm':
         return '채팅방';
       case '/social':
         return '소셜';

--- a/src/components/comment/CommentsSection.jsx
+++ b/src/components/comment/CommentsSection.jsx
@@ -83,7 +83,7 @@ const CommentsSection = ({ specId, isMyPage, currentUser }) => {
   };
 
   const handleSubmitComment = async () => {
-    if (!newComment.trim() || submitting) return;
+    if (!newComment.trim() || submitting || !specId) return;
 
     setSubmitting(true);
 
@@ -250,7 +250,7 @@ const CommentsSection = ({ specId, isMyPage, currentUser }) => {
       {/* 댓글 헤더 */}
       <div className="px-5 py-3 border-b border-gray-100">
         <h3 className="text-lg font-bold text-gray-800">
-          댓글 {totalElements}
+          댓글 {specId ? totalElements : 0}
         </h3>
       </div>
 
@@ -265,19 +265,28 @@ const CommentsSection = ({ specId, isMyPage, currentUser }) => {
               }
             }}
             onKeyPress={handleKeyPress}
-            placeholder="댓글을 입력하세요."
-            className="w-full p-4 pr-12 border border-gray-300 resize-none rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-            rows="2"
+            placeholder={
+              specId
+                ? '댓글을 입력하세요.'
+                : '스펙 입력 후 댓글을 작성할 수 있습니다.'
+            }
+            className={`w-full text-sm p-4 pr-12 border resize-none rounded-xl focus:outline-none 
+            ${
+              specId
+                ? 'border-gray-300 focus:ring-2 focus:ring-blue-500 focus:border-transparent'
+                : 'border-gray-300 bg-white cursor-not-allowed'
+            }`}
+            rows="1"
             maxLength={100}
-            disabled={submitting}
+            disabled={submitting || !specId}
             style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
           />
 
           <button
             onClick={handleSubmitComment}
-            disabled={!newComment.trim() || submitting}
+            disabled={!newComment.trim() || submitting || !specId}
             className={`absolute bottom-3 right-3 rounded-full flex items-center justify-center transition-colors ${
-              newComment.trim() && !submitting
+              newComment.trim() && !submitting && specId
                 ? 'text-blue-500 hover:text-blue-600'
                 : 'text-gray-400 cursor-not-allowed'
             }`}
@@ -296,7 +305,13 @@ const CommentsSection = ({ specId, isMyPage, currentUser }) => {
 
       {/* 댓글 목록 */}
       <div className="px-5 py-1">
-        {loading ? (
+        {!specId ? (
+          <div className="py-8 text-center">
+            <div className="text-gray-500">
+              스펙을 입력하고 <br /> 다른 사용자들과 소통해보세요!
+            </div>
+          </div>
+        ) : loading ? (
           <div className="py-8 text-center">
             <div className="text-gray-500">댓글을 불러오는 중...</div>
           </div>
@@ -321,7 +336,7 @@ const CommentsSection = ({ specId, isMyPage, currentUser }) => {
       </div>
 
       {/* 페이지네이션 */}
-      {!loading && totalPages > 0 && (
+      {specId && !loading && totalPages > 0 && (
         <div className="border-t border-gray-100">
           <Pagination
             currentPage={currentPage}

--- a/src/components/comment/Pagination.jsx
+++ b/src/components/comment/Pagination.jsx
@@ -7,6 +7,10 @@ import {
 } from 'lucide-react';
 
 const Pagination = ({ currentPage, totalPages, onPageChange }) => {
+  console.log('pagination props: ', { currentPage, totalPages });
+
+  if (totalPages <= 0) return null;
+
   const getVisiblePages = () => {
     const pages = [];
     const maxVisiblePages = 5;
@@ -31,17 +35,17 @@ const Pagination = ({ currentPage, totalPages, onPageChange }) => {
   };
 
   const visiblePages = getVisiblePages();
-  const currentGroup = Math.ceil(currentPage / 5);
-  const totalGroups = Math.ceil(totalPages / 5);
+  const isFirstPage = currentPage === 1;
+  const isLastPage = currentPage === totalPages;
 
   return (
-    <div className="flex items-center justify-center space-x-1 py-3">
+    <div className="flex items-center justify-center py-3 space-x-1">
       {/* 맨 첫 페이지로 */}
       <button
         onClick={() => onPageChange(1)}
-        disabled={currentPage === 1}
+        disabled={isFirstPage}
         className={`p-1 text-xs ${
-          currentPage === 1
+          isFirstPage
             ? 'text-gray-300 cursor-not-allowed'
             : 'text-gray-600 hover:text-gray-400'
         } transition-colors`}
@@ -51,10 +55,10 @@ const Pagination = ({ currentPage, totalPages, onPageChange }) => {
 
       {/* 이전 그룹으로 */}
       <button
-        onClick={() => onPageChange((currentGroup - 2) * 5 + 1)}
-        disabled={currentGroup === 1}
+        onClick={() => onPageChange(Math.max(1, currentPage - 1))}
+        disabled={isFirstPage}
         className={`p-1 text-xs ${
-          currentGroup === 1
+          isFirstPage
             ? 'text-gray-300 cursor-not-allowed'
             : 'text-gray-600 hover:text-gray-400'
         } transition-colors`}
@@ -79,10 +83,10 @@ const Pagination = ({ currentPage, totalPages, onPageChange }) => {
 
       {/* 다음 그룹으로 */}
       <button
-        onClick={() => onPageChange(currentGroup * 5 + 1)}
-        disabled={currentGroup === totalGroups}
+        onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
+        disabled={isLastPage}
         className={`p-1 text-xs ${
-          currentGroup === totalGroups
+          isLastPage
             ? 'text-gray-300 cursor-not-allowed'
             : 'text-gray-600 hover:text-gray-400'
         } transition-colors`}
@@ -93,9 +97,9 @@ const Pagination = ({ currentPage, totalPages, onPageChange }) => {
       {/* 맨 마지막 페이지로 */}
       <button
         onClick={() => onPageChange(totalPages)}
-        disabled={currentPage === totalPages}
+        disabled={isLastPage}
         className={`p-1 text-xs ${
-          currentPage === totalPages
+          isLastPage
             ? 'text-gray-300 cursor-not-allowed'
             : 'text-gray-600 hover:text-gray-400'
         } transition-colors`}

--- a/src/components/comment/Pagination.jsx
+++ b/src/components/comment/Pagination.jsx
@@ -7,8 +7,6 @@ import {
 } from 'lucide-react';
 
 const Pagination = ({ currentPage, totalPages, onPageChange }) => {
-  console.log('pagination props: ', { currentPage, totalPages });
-
   if (totalPages <= 0) return null;
 
   const getVisiblePages = () => {

--- a/src/components/ranking/RankingItem.jsx
+++ b/src/components/ranking/RankingItem.jsx
@@ -13,6 +13,7 @@ const RankingItem = React.memo(
     specId,
     nickname,
     profileImageUrl,
+    isOpenSpec,
     totalRank,
     totalUsersCount,
     rankByJobField,
@@ -95,10 +96,24 @@ const RankingItem = React.memo(
     const formattedJobField = jobField?.replace(/_/g, '·') || '';
 
     const handleDetailClick = () => {
-      if (specId) {
-        navigate(`/social/${specId}`);
-      } else {
+      if (!specId || !userId) {
         showToast('스펙 정보를 찾을 수 없습니다.', 'error');
+        return;
+      }
+
+      // 본인의 스펙인 경우 바로 이동
+      if (currentUser && currentUser.id === userId) {
+        navigate(`/social/${specId}?userId=${userId}`);
+        return;
+      }
+
+      // 타인의 스펙인 경우 공개 여부 확인
+      if (isOpenSpec) {
+        // 스펙이 공개된 경우 소셜 페이지로 이동
+        navigate(`/social/${specId}?userId=${userId}`);
+      } else {
+        // 스펙이 비공개인 경우 토스트 메시지 표시
+        showToast('비공개 스펙입니다.', 'error');
       }
     };
 

--- a/src/components/user/profile/ProfileCard.jsx
+++ b/src/components/user/profile/ProfileCard.jsx
@@ -1,5 +1,8 @@
 import { BriefcaseBusiness, Send, Star, Users } from 'lucide-react';
-import React from 'react';
+import React, { useState } from 'react';
+import useToast from '../../../hooks/useToast';
+import { ButtonLoadingIndicator } from '../../common/LoadingIndicator';
+import { BookmarkAPI } from '../../../api';
 
 const ProfileCard = ({
   profileImageUrl,
@@ -19,33 +22,87 @@ const ProfileCard = ({
   onDMClick,
   onFavoriteClick,
   isFavorite = false,
+  specId,
 }) => {
+  const [isBookmarkLoading, setIsBookmarkLoading] = useState(false);
+  const { showToast } = useToast();
+
+  const handleFavoriteClick = async () => {
+    if (!specId) {
+      showToast('스펙 정보를 찾을 수 없습니다.', 'error');
+      return;
+    }
+
+    if (isBookmarkLoading) return;
+
+    try {
+      setIsBookmarkLoading(true);
+
+      if (isFavorite) {
+        const response = await BookmarkAPI.removeBookmark(specId);
+        if (response.status === 204 || response.data?.isSuccess) {
+          showToast('즐겨찾기가 해제되었습니다.', 'success');
+          onFavoriteClick?.(specId, false, null);
+        } else {
+          showToast(
+            response.data.message || '즐겨찾기 해제에 실패했습니다.',
+            'error'
+          );
+        }
+      } else {
+        const response = await BookmarkAPI.addBookmark(specId);
+        if (response.data?.isSuccess) {
+          const newBookmarkId = response.data.data?.bookmarkId;
+          showToast('즐겨찾기가 등록되었습니다.', 'success');
+          onFavoriteClick?.(specId, true, newBookmarkId);
+        } else {
+          showToast(
+            response.data.message || '즐겨찾기 등록에 실패했습니다.',
+            'error'
+          );
+        }
+      }
+    } catch (error) {
+      console.error('즐겨찾기 처리 중 오류: ', error);
+
+      if (error.response?.status === 401) {
+        showToast('로그인이 필요한 기능입니다.', 'error');
+      } else if (error.response?.status === 404) {
+        showToast('해당 스펙을 찾을 수 없습니다.', 'error');
+      } else {
+        showToast('즐겨찾기 처리 중 오류가 발생했습니다.', 'error');
+      }
+    } finally {
+      setIsBookmarkLoading(false);
+    }
+  };
+
   return (
-    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 max-w-sm">
+    <div className="max-w-sm p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
       {/* 헤더 영역 */}
       <div className="flex items-start justify-between mb-3">
         <div className="flex items-center space-x-3">
-          <div className="w-12 h-12 bg-gray-200 flex items-center justify-center overflow-hidden">
+          <div className="flex items-center justify-center w-12 h-12 overflow-hidden bg-gray-200">
             {profileImageUrl ? (
               <img
                 src={profileImageUrl}
                 alt={nickname}
-                className="w-full h-full object-cover"
+                className="object-cover w-full h-full"
               />
             ) : (
               <div className="w-8 h-8 bg-gray-300 rounded"></div>
             )}
           </div>
           <div>
-            <h3 className="font-semibold text-gray-900 text-lg">{nickname}</h3>
-            <div className="flex items-center space-x-2 mt-1">
+            <h3 className="text-lg font-semibold text-gray-900">{nickname}</h3>
+            <div className="flex items-center mt-1 space-x-2">
               {jobField && (
                 <span className="inline-block bg-blue-100 text-blue-600 text-xs px-2 py-0.5 rounded-full">
                   {jobField}
                 </span>
               )}
               <div className="flex items-center space-x-2">
-                <span className="text-blue-600 font-semibold text-sm">
+                <span className="text-sm font-semibold text-blue-600">
                   · 총점 {totalScore}점
                 </span>
               </div>
@@ -62,8 +119,25 @@ const ProfileCard = ({
             >
               <Send size={18} />
             </button>
-            <button onClick={onFavoriteClick} className="p-2 text-yellow-500">
-              <Star size={18} fill={`${isFavorite ? 'yellow-400' : 'none'}`} />
+            <button
+              onClick={handleFavoriteClick}
+              disabled={isBookmarkLoading}
+              className={`p-2 text-yellow-500 ${isBookmarkLoading ? 'opacity-75' : ''}`}
+            >
+              {isBookmarkLoading ? (
+                <div className="flex items-center justify-center w-[18px] h-[18px]">
+                  <ButtonLoadingIndicator />
+                </div>
+              ) : (
+                <Star
+                  size={18}
+                  className={
+                    isFavorite
+                      ? 'text-yellow-400 fill-yellow-400'
+                      : 'text-yellow-400'
+                  }
+                />
+              )}
             </button>
           </div>
         )}
@@ -71,11 +145,11 @@ const ProfileCard = ({
 
       {/* 순위 정보 또는 가입일 */}
       {showRanking ? (
-        <div className="bg-gray-50 p-3 rounded-lg font-semibold">
-          <div className="flex justify-between items-center text-blue-600">
+        <div className="p-3 font-semibold rounded-lg bg-gray-50">
+          <div className="flex items-center justify-between text-blue-600">
             <div className="flex items-center space-x-2">
               <BriefcaseBusiness />
-              <span className="text-blue-600 text-sm">직무 내 순위</span>
+              <span className="text-sm text-blue-600">직무 내 순위</span>
             </div>
             <div className="text-right">
               <span>
@@ -84,10 +158,10 @@ const ProfileCard = ({
               <div className="text-xs">상위 {jobFieldRankPercent}%</div>
             </div>
           </div>
-          <div className="flex justify-between items-center mt-2">
+          <div className="flex items-center justify-between mt-2">
             <div className="flex items-center space-x-2">
               <Users />
-              <span className="text-gray-600 text-sm">전체 순위</span>
+              <span className="text-sm text-gray-600">전체 순위</span>
             </div>
             <div className="text-right">
               <span className="text-gray-600">
@@ -100,8 +174,8 @@ const ProfileCard = ({
           </div>
         </div>
       ) : showJoinDate ? (
-        <div className="border-t border-gray-100 pt-3 mt-3">
-          <div className="flex justify-between items-center text-sm text-gray-500">
+        <div className="pt-3 mt-3 border-t border-gray-100">
+          <div className="flex items-center justify-between text-sm text-gray-500">
             <span>가입일</span>
             <span>{joinDate}</span>
           </div>

--- a/src/components/user/profile/SocialProfileCard.jsx
+++ b/src/components/user/profile/SocialProfileCard.jsx
@@ -9,6 +9,7 @@ const SocialProfileCard = ({
   onDMClick,
   onFavoriteClick,
   isFavorite,
+  specId,
 }) => {
   // 스펙이 없는 경우
   if (!hasSpec) {
@@ -43,6 +44,7 @@ const SocialProfileCard = ({
       onDMClick={onDMClick}
       onFavoriteClick={onFavoriteClick}
       isFavorite={isFavorite}
+      specId={specId}
     />
   );
 };

--- a/src/pages/SocialPage.jsx
+++ b/src/pages/SocialPage.jsx
@@ -4,7 +4,7 @@ import { useAuthStore } from '../stores/useAuthStore';
 import { BarChart3, FileText } from 'lucide-react';
 import SocialProfileCard from '../components/user/profile/SocialProfileCard';
 import RadarChart from '../components/spec-analysis/RadarChart';
-import { SpecAPI, UserAPI } from '../api';
+import { SpecAPI, UserAPI, BookmarkAPI } from '../api';
 import CommentsSection from '../components/comment/CommentsSection';
 
 const SocialPage = () => {
@@ -69,6 +69,23 @@ const SocialPage = () => {
       return () => clearTimeout(timer);
     }
   }, [activeTab]);
+
+  // loadPageData 함수에서 타인 페이지 처리 부분에 추가
+  const checkBookmarkStatus = async (specId) => {
+    try {
+      const bookmarkResponse = await BookmarkAPI.getBookmarks({ cursor: null });
+      if (bookmarkResponse.data.isSuccess) {
+        const bookmarks = bookmarkResponse.data.data.bookmarks;
+        return bookmarks.some(
+          (bookmark) => bookmark.spec.id === parseInt(specId)
+        );
+      }
+      return false;
+    } catch (error) {
+      console.error('즐겨찾기 상태 확인 실패:', error);
+      return false;
+    }
+  };
 
   const loadPageData = async () => {
     try {
@@ -162,6 +179,7 @@ const SocialPage = () => {
 
         if (userResponse.data.isSuccess) {
           const userInfo = userResponse.data.data.user;
+          console.log('userInfo: ', userInfo);
 
           if (!userInfo.isOpenSpec) {
             console.log('스펙이 비공개 상태입니다.');
@@ -234,7 +252,8 @@ const SocialPage = () => {
             }
 
             setUserData(profileData);
-            setIsBookmarked(specDetailData.isBookmarked || false);
+            const bookmarkStatus = await checkBookmarkStatus(specId);
+            setIsBookmarked(bookmarkStatus);
           } else {
             console.error('스펙 정보 조회 실패:', specResponse.data?.message);
             throw new Error('스펙 정보를 불러올 수 없습니다.');

--- a/src/pages/SocialPage.jsx
+++ b/src/pages/SocialPage.jsx
@@ -187,12 +187,12 @@ const SocialPage = () => {
             setHasSpec(false);
             return;
           }
-          console.log('어디냐?');
+
           const specResponse = await SpecAPI.getSpecDetail(specId);
-          console.log('여기다! ', specResponse);
-          if (specResponse.data?.isSuccess) {
-            const specDetailData = specResponse.specDetailData;
-            const rankings = specDetailData.rankings?.details;
+
+          if (specResponse.data.isSuccess) {
+            const specDetailData = specResponse.data.specDetailData;
+            const rankings = specDetailData.rankings.details;
 
             setSpecData(specDetailData);
             setHasSpec(true);
@@ -256,14 +256,12 @@ const SocialPage = () => {
     console.log('DM 버튼 클릭');
   };
 
-  const handleBookmarkChange = useCallback((specId, isBookmarked) => {
-    setIsBookmarked(isBookmarked);
-    setSpecData((prevData) =>
-      prevData.map((item) =>
-        item.specId === specId ? { ...item, isBookmarked } : item
-      )
-    );
-  }, []);
+  const handleBookmarkChange = useCallback(
+    (specId, isBookmarked, bookmarkId) => {
+      setIsBookmarked(isBookmarked);
+    },
+    []
+  );
 
   if (loading) {
     return (
@@ -291,6 +289,7 @@ const SocialPage = () => {
           onDMClick={handleDMClick}
           onFavoriteClick={handleBookmarkChange}
           isFavorite={isBookmarked}
+          specId={specId}
         />
 
         {/* 스펙 분석 카드 */}


### PR DESCRIPTION
## ☝️ 요약
- 소셜페이지 관련 기능 추가/수정

<br/>

## ✏️ 상세 내용
- 상세보기 버튼 클릭 시 타인의 소셜페이지 이동 + 비공개 스펙은 접근할 수 없음
- 여러 페이지에 존재하는 즐겨찾기 버튼 상태가 동기화되도록 구현
- 댓글 삭제할 때마다 페이지네이션 새로고침
- 스펙 없을 시 댓글 작성 불가

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 로컬 테스트 완료했습니다.
- [x] Assignee를 지정했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)