### PR TITLE
fix: "미로그인 / 로그인 & 스펙 미입력 / 로그인 & 스펙 입력" 상태에 따른 화면 구성 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -61,11 +61,11 @@ const Layout = ({ children }) => {
   const navigate = useNavigate();
   const path = location.pathname;
   const { isLoggedIn } = useAuthStore();
-  const { toasts, removeToast, showError } = useToast();
+  const { toasts, removeToast, showToast } = useToast();
 
   // 로그인 필요 토스트 표시 함수
   const showLoginRequiredToast = () => {
-    showError('로그인이 필요한 기능입니다!');
+    showToast('로그인 후 더 많은 기능을 경험해보세요!', 'info');
   };
 
   // 현재 경로에 따라 TopBar 타이틀 설정

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,8 @@ import BottomNavBar from './components/common/BottomNavBar';
 import { useEffect } from 'react';
 import { useAuthStore } from './stores/useAuthStore';
 import OAuthRedirectPage from './pages/OAuthRedirectPage';
+import ToastContainer from './components/common/ToastContainer';
+import useToast from './hooks/useToast';
 
 axios.defaults.withCredentials = true;
 
@@ -59,6 +61,12 @@ const Layout = ({ children }) => {
   const navigate = useNavigate();
   const path = location.pathname;
   const { isLoggedIn } = useAuthStore();
+  const { toasts, removeToast, showError } = useToast();
+
+  // 로그인 필요 토스트 표시 함수
+  const showLoginRequiredToast = () => {
+    showError('로그인이 필요한 기능입니다!');
+  };
 
   // 현재 경로에 따라 TopBar 타이틀 설정
   const getTitleByPath = () => {
@@ -145,7 +153,12 @@ const Layout = ({ children }) => {
       >
         <div className="h-full">{children}</div>
       </main>
-      <BottomNavBar active={getActiveMenu()} />
+      <BottomNavBar
+        active={getActiveMenu()}
+        showToast={showLoginRequiredToast}
+      />
+
+      <ToastContainer toasts={toasts} removeToast={removeToast} />
     </div>
   );
 };

--- a/src/components/common/BottomNavBar.jsx
+++ b/src/components/common/BottomNavBar.jsx
@@ -1,10 +1,16 @@
 import React, { useState, useEffect } from 'react';
-import { Home, BarChart2, MessageSquare, Users, CircleUserRound } from 'lucide-react';
+import {
+  Home,
+  BarChart2,
+  MessageSquare,
+  Users,
+  CircleUserRound,
+} from 'lucide-react';
 import { useAuthStore } from '../../stores/useAuthStore';
 import { getAccessToken } from '../../utils/token';
 import { NotificationAPI } from '../../api';
 
-const BottomNavBar = ({ active }) => {
+const BottomNavBar = ({ active, showToast }) => {
   const { isLoggedIn, loading } = useAuthStore();
   const token = getAccessToken();
 
@@ -12,46 +18,46 @@ const BottomNavBar = ({ active }) => {
 
   const [notifications, setNotifications] = useState({
     hasUnreadChat: false,
-    hasUnreadComment: false
+    hasUnreadComment: false,
   });
-  
+
   // 알림 상태 가져오기
   useEffect(() => {
     const fetchNotifications = async () => {
       if (!isLoggedIn) return;
-      
+
       try {
         const response = await NotificationAPI.getNotifications('footer');
-        
+
         if (response.data.success) {
           setNotifications({
             hasUnreadChat: response.data.data.hasUnreadChat,
-            hasUnreadComment: response.data.data.hasUnreadComment
+            hasUnreadComment: response.data.data.hasUnreadComment,
           });
         }
       } catch (error) {
         console.error('알림 상태 조회 실패:', error);
       }
     };
-    
+
     fetchNotifications();
-    
+
     // 주기적으로 알림 상태 업데이트 (1분마다)
     const intervalId = setInterval(fetchNotifications, 60000);
-    
+
     return () => clearInterval(intervalId);
   }, [isLoggedIn, active]);
-  
+
   // 채팅방 알림 삭제
   const clearChatNotification = async () => {
     if (!isLoggedIn || !notifications.hasUnreadChat) return;
-    
+
     // 즉시 로컬 상태 업데이트 (UI가 즉시 반응하도록)
-    setNotifications(prev => ({
+    setNotifications((prev) => ({
       ...prev,
-      hasUnreadChat: false
+      hasUnreadChat: false,
     }));
-    
+
     // 서버에 삭제 요청
     try {
       await NotificationAPI.deleteNotifications('chat');
@@ -59,17 +65,17 @@ const BottomNavBar = ({ active }) => {
       console.error('채팅 알림 삭제 실패:', error);
     }
   };
-  
+
   // 소셜 알림 삭제
   const clearSocialNotification = async () => {
     if (!isLoggedIn || !notifications.hasUnreadComment) return;
-    
+
     // 즉시 로컬 상태 업데이트 (UI가 즉시 반응하도록)
-    setNotifications(prev => ({
+    setNotifications((prev) => ({
       ...prev,
-      hasUnreadComment: false
+      hasUnreadComment: false,
     }));
-    
+
     // 서버에 삭제 요청
     try {
       await NotificationAPI.deleteNotifications('social');
@@ -78,7 +84,24 @@ const BottomNavBar = ({ active }) => {
     }
   };
 
-  
+  const handleNavClick = (e, item) => {
+    // 로그인이 필요한 기능인지 확인
+    if (!isAuthenticated && (item.name === 'DM' || item.name === 'SOCIAL')) {
+      e.preventDefault(); // 기본 링크 동작 방지
+      if (showToast) showToast();
+      return;
+    }
+
+    // 로그인된 상태에서 알림 삭제
+    if (isAuthenticated) {
+      if (item.name === 'SOCIAL') {
+        clearSocialNotification();
+      } else if (item.name === 'DM') {
+        clearChatNotification();
+      }
+    }
+  };
+
   // 기본 네비게이션 아이템
   const baseNavItems = [
     { name: 'HOME', icon: Home, path: '/' },
@@ -86,40 +109,36 @@ const BottomNavBar = ({ active }) => {
     { name: 'DM', icon: MessageSquare, path: '/chatrooms' },
     { name: 'SOCIAL', icon: Users, path: '/social' },
   ];
-  
+
   // 로그인 상태에 따라 마지막 아이템 추가
   const navItems = [
     ...baseNavItems,
     isAuthenticated
       ? { name: 'MY', icon: CircleUserRound, path: '/my' }
-      : { name: 'LOGIN', icon: CircleUserRound, path: '/login' }
+      : { name: 'LOGIN', icon: CircleUserRound, path: '/login' },
   ];
 
   return (
     <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-[390px] h-16 bg-white flex justify-between items-center px-2 border-t border-gray-100">
       {navItems.map((item) => (
-        <a 
+        <a
           key={item.name}
           href={item.path}
           className={`flex flex-col items-center justify-center w-16 h-full ${
-            active === item.name.toLowerCase() ? 'text-blue-500' : 'text-gray-500'
+            active === item.name.toLowerCase()
+              ? 'text-blue-500'
+              : 'text-gray-500'
           } relative`}
-          onClick={(e) => {
-            if (item.name === 'SOCIAL') {
-              clearSocialNotification(); // 소셜 알림 삭제
-            } else if (item.name === 'DM') {
-              clearChatNotification(); // 채팅방 알림 삭제
-            }
-          }}        
+          onClick={(e) => handleNavClick(e, item)}
         >
           <item.icon size={20} />
           <span className="mt-1 text-xs">{item.name}</span>
-          
+
           {/* 채팅 알림 표시 */}
           {item.name === 'DM' && notifications.hasUnreadChat && (
             <div className="absolute top-0 w-2 h-2 bg-red-500 rounded-full right-2"></div>
           )}
-          
+
           {/* 댓글 알림 표시 */}
           {item.name === 'SOCIAL' && notifications.hasUnreadComment && (
             <div className="absolute top-0 w-2 h-2 bg-red-500 rounded-full right-2"></div>

--- a/src/components/common/Toast.jsx
+++ b/src/components/common/Toast.jsx
@@ -1,86 +1,93 @@
-import React, { useState, useEffect} from 'react';
-import { CheckCircle, XCircle, X } from 'lucide-react';
+import React, { useState, useEffect } from 'react';
+import { CheckCircle, XCircle, Info, X } from 'lucide-react';
 
-const Toast = ({ 
-    type = 'success', 
-    message, 
-    isVisible = false, 
-    onClose, 
-    duration = 1000,
-    position = 'top-center'
+const Toast = ({
+  type = 'success',
+  message,
+  isVisible = false,
+  onClose,
+  duration = 1000,
+  position = 'top-center',
 }) => {
-    const [show, setShow] = useState(isVisible);
+  const [show, setShow] = useState(isVisible);
 
-    useEffect(() => {
-      setShow(isVisible);
-      
-      if (isVisible && duration > 0) {
-        const timer = setTimeout(() => {
-          setShow(false);
-          setTimeout(() => onClose && onClose(), 300); 
-        }, duration);
-        
-        return () => clearTimeout(timer);
-      }
-    }, [isVisible, duration, onClose]);
-  
-    const handleClose = () => {
-      setShow(false);
-      setTimeout(() => onClose && onClose(), 300);
+  useEffect(() => {
+    setShow(isVisible);
+
+    if (isVisible && duration > 0) {
+      const timer = setTimeout(() => {
+        setShow(false);
+        setTimeout(() => onClose && onClose(), 300);
+      }, duration);
+
+      return () => clearTimeout(timer);
+    }
+  }, [isVisible, duration, onClose]);
+
+  const handleClose = () => {
+    setShow(false);
+    setTimeout(() => onClose && onClose(), 300);
+  };
+
+  const getToastStyles = () => {
+    const baseStyles =
+      'fixed z-50 flex items-center justify-between p-4 text-sm rounded-lg shadow-lg min-w-80 max-w-md transition-all duration-300 ease-in-out';
+
+    const positionStyles = {
+      'top-center': 'top-4 left-1/2 transform -translate-x-1/2',
+      'top-right': 'top-4 right-4',
+      'bottom-center': 'bottom-4 left-1/2 transform -translate-x-1/2',
+      'bottom-right': 'bottom-4 right-4',
     };
-  
-    const getToastStyles = () => {
-      const baseStyles = "fixed z-50 flex items-center justify-between p-4 rounded-lg shadow-lg min-w-80 max-w-md transition-all duration-300 ease-in-out";
-      
-      const positionStyles = {
-        'top-center': 'top-4 left-1/2 transform -translate-x-1/2',
-        'top-right': 'top-4 right-4',
-        'bottom-center': 'bottom-4 left-1/2 transform -translate-x-1/2',
-        'bottom-right': 'bottom-4 right-4'
-      };
-  
-      const typeStyles = {
-        success: 'bg-green-100 border border-green-400 text-green-700',
-        error: 'bg-red-100 border border-red-400 text-red-700'
-      };
-  
-      const visibilityStyles = show 
-        ? 'opacity-100 translate-y-0 scale-100' 
-        : 'opacity-0 -translate-y-2 scale-95 pointer-events-none';
-  
-      return `${baseStyles} ${positionStyles[position]} ${typeStyles[type]} ${visibilityStyles}`;
+
+    const typeStyles = {
+      success: 'bg-green-100 border border-green-400 text-green-700',
+      error: 'bg-red-100 border border-red-400 text-red-700',
+      info: 'bg-yellow-100 border border-yellow-400 text-yellow-700',
     };
-  
-    const getIcon = () => {
-      if (type === 'success') {
-        return (
-          <div className="flex-shrink-0 mr-3">
-            <CheckCircle size={20} className="text-green-500" />
-          </div>
-        );
-      } else {
-        return (
-          <div className="flex-shrink-0 mr-3">
-            <XCircle size={20} className="text-red-500" />
-          </div>
-        );
-      }
-    };
-  
-    return (
-        <div className={getToastStyles()}>
-        {getIcon()}
-        <span className="flex-1 font-medium">
-            {message}
-        </span>
-        <button
-            onClick={handleClose}
-            className="flex-shrink-0 ml-3 text-gray-400 hover:text-gray-600 transition-colors duration-200"
-        >
-            <X size={16} />
-        </button>
+
+    const visibilityStyles = show
+      ? 'opacity-100 translate-y-0 scale-100'
+      : 'opacity-0 -translate-y-2 scale-95 pointer-events-none';
+
+    return `${baseStyles} ${positionStyles[position]} ${typeStyles[type]} ${visibilityStyles}`;
+  };
+
+  const getIcon = () => {
+    if (type === 'success') {
+      return (
+        <div className="flex-shrink-0 mr-3">
+          <CheckCircle size={20} className="text-green-500" />
         </div>
-    );
+      );
+    } else if (type === 'error') {
+      return (
+        <div className="flex-shrink-0 mr-3">
+          <XCircle size={20} className="text-red-500" />
+        </div>
+      );
+    } else if (type === 'info') {
+      return (
+        <div className="flex-shrink-0 mr-3">
+          <Info size={20} className="text-yellow-500" />
+        </div>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <div className={getToastStyles()}>
+      {getIcon()}
+      <span className="flex-1 font-medium">{message}</span>
+      <button
+        onClick={handleClose}
+        className="flex-shrink-0 ml-3 text-gray-400 transition-colors duration-200 hover:text-gray-600"
+      >
+        <X size={16} />
+      </button>
+    </div>
+  );
 };
 
 export default Toast;

--- a/src/components/ranking/RankingItem.jsx
+++ b/src/components/ranking/RankingItem.jsx
@@ -96,6 +96,11 @@ const RankingItem = React.memo(
     const formattedJobField = jobField?.replace(/_/g, '·') || '';
 
     const handleDetailClick = () => {
+      if (!isLoggedIn) {
+        showToast('로그인 후 세부 스펙을 확인해보세요!', 'info');
+        return;
+      }
+
       if (!specId || !userId) {
         showToast('스펙 정보를 찾을 수 없습니다.', 'error');
         return;
@@ -113,7 +118,7 @@ const RankingItem = React.memo(
         navigate(`/social/${specId}?userId=${userId}`);
       } else {
         // 스펙이 비공개인 경우 토스트 메시지 표시
-        showToast('비공개 스펙입니다.', 'error');
+        showToast('비공개 설정된 스펙입니다.', 'info');
       }
     };
 
@@ -178,7 +183,7 @@ const RankingItem = React.memo(
     };
 
     return (
-      <div className="bg-white rounded-lg shadow-sm my-1 p-4">
+      <div className="p-4 my-1 bg-white rounded-lg shadow-sm">
         <div className="flex items-center mb-2">
           <div className="flex items-center justify-center min-w-[40px] mr-3">
             <Medal rank={rankingInfo.rank} />

--- a/src/components/spec-analysis/RadarChart.jsx
+++ b/src/components/spec-analysis/RadarChart.jsx
@@ -2,12 +2,22 @@ import React from 'react';
 import { GraduationCap, Briefcase, Award, BookOpen, Users } from 'lucide-react';
 
 const RadarChart = ({ animatedScores, isAnalyzing }) => {
+  if (!animatedScores) {
+    return (
+      <div className="py-8 text-center text-gray-500">
+        스펙 정보를 입력하고
+        <br />
+        AI 분석 결과를 확인해보세요.
+      </div>
+    );
+  }
+
   const specData = [
-    { category: '학력', score: 50, icon: GraduationCap, colorHex: '#3b82f6' },
+    { category: '학력', score: 0, icon: GraduationCap, colorHex: '#3b82f6' },
     { category: '경험', score: 0, icon: Briefcase, colorHex: '#8b5cf6' },
-    { category: '자격증', score: 60, icon: Award, colorHex: '#10b981' },
-    { category: '어학', score: 75, icon: BookOpen, colorHex: '#f59e0b' },
-    { category: '활동', score: 85, icon: Users, colorHex: '#ef4444' },
+    { category: '자격증', score: 0, icon: Award, colorHex: '#10b981' },
+    { category: '어학', score: 0, icon: BookOpen, colorHex: '#f59e0b' },
+    { category: '활동', score: 0, icon: Users, colorHex: '#ef4444' },
   ];
 
   const size = 180;
@@ -123,13 +133,13 @@ const RadarChart = ({ animatedScores, isAnalyzing }) => {
             className="absolute text-xs font-medium transform -translate-x-1/2 -translate-y-1/2"
             style={{ left: point.labelX, top: point.labelY }}
           >
-            <div className="bg-white px-2 py-1 rounded-lg shadow-sm border text-center">
+            <div className="px-2 py-1 text-center bg-white border rounded-lg shadow-sm">
               <div className="flex items-center justify-center mb-1">
                 <IconComponent size={10} style={{ color: point.colorHex }} />
               </div>
-              <div className="text-gray-600 text-xs">{point.category}</div>
+              <div className="text-xs text-gray-600">{point.category}</div>
               <div
-                className="font-bold text-xs"
+                className="text-xs font-bold"
                 style={{ color: point.colorHex }}
               >
                 {point.animatedScore}

--- a/src/components/spec-analysis/SpecDetailTab.jsx
+++ b/src/components/spec-analysis/SpecDetailTab.jsx
@@ -4,7 +4,9 @@ const SpecDetailInfo = ({ specData }) => {
   if (!specData) {
     return (
       <div className="py-8 text-center text-gray-500">
-        스펙 정보를 불러올 수 없습니다.
+        스펙 정보를 입력하고
+        <br />
+        AI 분석에 기반한 점수를 확인해보세요.
       </div>
     );
   }

--- a/src/components/user/profile/SocialProfileCard.jsx
+++ b/src/components/user/profile/SocialProfileCard.jsx
@@ -17,7 +17,7 @@ const SocialProfileCard = ({
       <NoSpecCard
         profileImageUrl={userData.profileImageUrl}
         nickname={userData.nickname}
-        showButtons={true}
+        showButtons={showButtons}
         onDMClick={onDMClick}
         onFavoriteClick={onFavoriteClick}
         isFavorite={isFavorite}

--- a/src/hooks/useToast.js
+++ b/src/hooks/useToast.js
@@ -1,36 +1,42 @@
 import { useCallback, useState } from 'react';
 
-export default function useToast () {
-    const [toasts, setToasts] = useState([]);
-  
-    const showToast = useCallback((message, type = 'success', options = {}) => {
-        const isDuplicate = toasts.some(
-            toast => toast.message === message && toast.type === type && toast.isVisible
-        );
-        if (isDuplicate) return null;
-        
-        const id = Date.now() + Math.random();
-        setToasts(prev => [
-            ...prev,
-            { id, message, type, isVisible: true, ...options }
-        ]);
-        return id;
-    }, [toasts]);
-  
-    const removeToast = useCallback((id) => {
-        setToasts(prev =>
-            prev.map(toast =>
-              toast.id === id ? { ...toast, isVisible: false } : toast
-            )
-          );
+export default function useToast() {
+  const [toasts, setToasts] = useState([]);
 
-          setTimeout(() => {
-            setToasts(prev => prev.filter(toast => toast.id !== id));
-          }, 300);
-    }, []);
-  
-    const showSuccess = (message, options) => showToast(message, 'success', options);
-    const showError = (message, options) => showToast(message, 'error', options);
-  
-    return { toasts, showToast, removeToast, showSuccess, showError };
-  };
+  const showToast = useCallback(
+    (message, type = 'success', options = {}) => {
+      const isDuplicate = toasts.some(
+        (toast) =>
+          toast.message === message && toast.type === type && toast.isVisible
+      );
+      if (isDuplicate) return null;
+
+      const id = Date.now() + Math.random();
+      setToasts((prev) => [
+        ...prev,
+        { id, message, type, isVisible: true, ...options },
+      ]);
+      return id;
+    },
+    [toasts]
+  );
+
+  const removeToast = useCallback((id) => {
+    setToasts((prev) =>
+      prev.map((toast) =>
+        toast.id === id ? { ...toast, isVisible: false } : toast
+      )
+    );
+
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((toast) => toast.id !== id));
+    }, 300);
+  }, []);
+
+  const showSuccess = (message, options) =>
+    showToast(message, 'success', options);
+  const showError = (message, options) => showToast(message, 'error', options);
+  const showInfo = (message, options) => showToast(message, 'info', options);
+
+  return { toasts, showToast, removeToast, showSuccess, showError, showInfo };
+}

--- a/src/pages/SocialPage.jsx
+++ b/src/pages/SocialPage.jsx
@@ -35,7 +35,7 @@ const SocialPage = () => {
   // 실제 스펙 점수를 specData에서 가져오도록 수정
   const getActualScores = () => {
     if (!specData?.rankings?.categories) {
-      return [50, 0, 60, 75, 85]; // 기본값
+      return [0, 0, 0, 0, 0]; // 기본값
     }
 
     return specData.rankings.categories.map((category) =>


### PR DESCRIPTION
## ☝️ 요약
"미로그인 / 로그인 & 스펙 미입력 / 로그인 & 스펙 입력" 상태에 따른 화면 구성 수정

<br/>

## ✏️ 상세 내용
- 로그인하지 않은 사용자가 DM, SOCIAL 탭 클릭 시 접속 못하게 막기 + 토스트메시지 띄우기
    - BottomNavBar.jsx, App.jsx 수정
- 미로그인 시 ‘상세보기’ 클릭 막기
    - Toast 종류 info 추가함 (노란색)
- 내 소셜페이지에서 DM, Bookmark 버튼 나타나는 문제 수정
    - SocialProfileCard에서 NoSpecCard에 넘겨주는 showButtons props 값 수정
- 스펙 미입력한 소셜페이지에서 스펙분석탭 안 보이도록 하기
    - RadarChart는 default 값을 0 * 5개로 수정해서 초기화된 차트 형태로 둠
    - 세부스펙정보 탭 예외처리 완료

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.
- [x] 로컬 테스트 완료했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)