### PR TITLE
feat: 소셜페이지 dm 버튼 클릭 시 채팅 페이지로 이동하는 기능 구현

### DIFF
--- a/src/components/ranking/RankingItem.jsx
+++ b/src/components/ranking/RankingItem.jsx
@@ -134,12 +134,6 @@ const RankingItem = React.memo(
         return;
       }
 
-      console.log('즐겨찾기 버튼 클릭:', {
-        specId,
-        isBookmarked,
-        action: isBookmarked ? '해제' : '등록',
-      });
-
       try {
         setIsBookmarkLoading(true);
 

--- a/src/pages/ProfileSetupPage.jsx
+++ b/src/pages/ProfileSetupPage.jsx
@@ -82,7 +82,7 @@ const ProfileSetupPage = () => {
       if (accessToken && response.data) {
         setAccessToken(accessToken);
         deleteCookie('access');
-        console.log(response.data.message, response.data.data);
+
         login(response.data.data, accessToken);
         showToast('회원가입이 완료되었습니다!', 'success');
 


### PR DESCRIPTION
## ☝️ 요약
소셜페이지 dm 버튼 클릭 시 채팅 페이지로 이동하는 기능 구현

<br/>

## ✏️ 상세 내용
- dm 버튼 클릭 시 채팅 페이지로 이동 
- 채팅 페이지 이동 로직
  - get chatroom-participations를 호출해서 partnerId가 있는지 살펴본다.
  - 있으면 chatroom과 partnerId를 sessionStorage에 넣는다.
  - 없으면 chatroom은 제거하고 partnerId를 sessionStorage에 넣는다.
  - /chat으로 이동한다.

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.
- [x] 로컬 테스트 완료했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)
- 채팅 페이지에서 채팅 전송 시 일부 오류 존재하는 상태임