### PR TITLE
fix: 즐겨찾기 상태 props 전달 방식에서 전역 상태 관리로 변경

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,7 @@ import TopBar from './components/common/TopBar';
 import BottomNavBar from './components/common/BottomNavBar';
 import { useEffect } from 'react';
 import { useAuthStore } from './stores/useAuthStore';
+import { useBookmarkStore } from './stores/useBookmarkStore';
 import OAuthRedirectPage from './pages/OAuthRedirectPage';
 import ToastContainer from './components/common/ToastContainer';
 import useToast from './hooks/useToast';
@@ -153,7 +154,6 @@ const Layout = ({ children }) => {
         className={`${isChatPage ? '' : 'pt-14 pb-16'} min-h-[calc(100vh-120px)]`}
       >
         <div className="h-full">{children}</div>
-
       </main>
       <BottomNavBar
         active={getActiveMenu()}
@@ -167,9 +167,19 @@ const Layout = ({ children }) => {
 
 function App() {
   const init = useAuthStore((s) => s.init);
+  const { isLoggedIn } = useAuthStore();
+  const { initializeBookmarks, initialized } = useBookmarkStore();
+
   useEffect(() => {
     init();
   }, [init]);
+
+  // 로그인 상태가 변경되면 즐겨찾기 초기화
+  useEffect(() => {
+    if (isLoggedIn && !initialized) {
+      initializeBookmarks();
+    }
+  }, [isLoggedIn, initialized, initializeBookmarks]);
 
   return (
     <BrowserRouter>
@@ -287,4 +297,3 @@ function App() {
 }
 
 export default App;
-

--- a/src/components/user/profile/NoSpecCard.jsx
+++ b/src/components/user/profile/NoSpecCard.jsx
@@ -1,5 +1,8 @@
 import { Send, Star } from 'lucide-react';
-import React from 'react';
+import React, { useState } from 'react';
+import { useBookmarkStore } from '../../../stores/useBookmarkStore';
+import useToast from '../../../hooks/useToast';
+import { ButtonLoadingIndicator } from '../../common/LoadingIndicator';
 
 const NoSpecCard = ({
   profileImageUrl,
@@ -9,9 +12,20 @@ const NoSpecCard = ({
   showButtons = false,
   onDMClick,
   onFavoriteClick,
-  isFavorite = false,
   variant = 'default',
 }) => {
+  const [isBookmarkLoading, setIsBookmarkLoading] = useState(false);
+  const { showToast } = useToast();
+  const { loading: bookmarkStoreLoading } = useBookmarkStore();
+
+  // 스펙이 없는 사용자는 즐겨찾기할 수 없으므로 항상 false
+  const isFavorite = false;
+
+  const handleFavoriteClick = async () => {
+    // 스펙이 없는 사용자는 즐겨찾기할 수 없음
+    showToast('스펙이 있는 사용자만 즐겨찾기할 수 있습니다.', 'info');
+  };
+
   return (
     <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 max-w-sm">
       {/* 헤더 영역 */}
@@ -47,8 +61,18 @@ const NoSpecCard = ({
             >
               <Send size={18} />
             </button>
-            <button onClick={onFavoriteClick} className="p-2 text-yellow-500">
-              <Star size={18} fill={`${isFavorite ? 'yellow-400' : 'none'}`} />
+            <button
+              onClick={handleFavoriteClick}
+              disabled={isBookmarkLoading || bookmarkStoreLoading}
+              className={`p-2 text-yellow-500 ${isBookmarkLoading || bookmarkStoreLoading ? 'opacity-75' : ''}`}
+            >
+              {isBookmarkLoading || bookmarkStoreLoading ? (
+                <div className="flex items-center justify-center w-[18px] h-[18px]">
+                  <ButtonLoadingIndicator />
+                </div>
+              ) : (
+                <Star size={18} className="text-yellow-400" />
+              )}
             </button>
           </div>
         )}

--- a/src/components/user/profile/SocialProfileCard.jsx
+++ b/src/components/user/profile/SocialProfileCard.jsx
@@ -8,7 +8,6 @@ const SocialProfileCard = ({
   showButtons,
   onDMClick,
   onFavoriteClick,
-  isFavorite,
   specId,
 }) => {
   // 스펙이 없는 경우
@@ -20,7 +19,6 @@ const SocialProfileCard = ({
         showButtons={showButtons}
         onDMClick={onDMClick}
         onFavoriteClick={onFavoriteClick}
-        isFavorite={isFavorite}
         variant="social"
       />
     );
@@ -43,7 +41,6 @@ const SocialProfileCard = ({
       showButtons={showButtons}
       onDMClick={onDMClick}
       onFavoriteClick={onFavoriteClick}
-      isFavorite={isFavorite}
       specId={specId}
     />
   );

--- a/src/pages/BookmarkPage.jsx
+++ b/src/pages/BookmarkPage.jsx
@@ -58,7 +58,6 @@ const BookmarkPage = () => {
                   usersCountByJobField: bookmark.spec.jobFieldUserCount,
                   score: bookmark.spec.score,
                   jobField: bookmark.spec.jobField,
-                  isBookmarked: bookmark.spec.isBookmarked,
                   commentsCount: bookmark.spec.commentsCount,
                   bookmarksCount: bookmark.spec.bookmarksCount,
                 };
@@ -78,7 +77,6 @@ const BookmarkPage = () => {
                   usersCountByJobField: bookmark.spec.jobFieldUserCount,
                   score: bookmark.spec.score,
                   jobField: bookmark.spec.jobField,
-                  isBookmarked: bookmark.spec.isBookmarked,
                   commentsCount: bookmark.spec.commentsCount,
                   bookmarksCount: bookmark.spec.bookmarksCount,
                 };
@@ -130,16 +128,9 @@ const BookmarkPage = () => {
   const handleBookmarkChange = useCallback(
     (specId, isBookmarked, bookmarkId) => {
       if (!isBookmarked) {
+        // 즐겨찾기 해제 시 목록에서 제거
         setBookmarks((prev) => prev.filter((item) => item.specId !== specId));
         showToast('즐겨찾기가 해제되었습니다.', 'success');
-      } else {
-        setBookmarks((prev) =>
-          prev.map((item) =>
-            item.specId === specId
-              ? { ...item, isBookmarked, bookmarkId }
-              : item
-          )
-        );
       }
     },
     [showToast]
@@ -250,7 +241,6 @@ const BookmarkPage = () => {
                   usersCountByJobField={bookmark.usersCountByJobField}
                   score={bookmark.score}
                   jobField={bookmark.jobField}
-                  isBookmarked={bookmark.isBookmarked}
                   commentsCount={bookmark.commentsCount}
                   bookmarksCount={bookmark.bookmarksCount}
                   selectedFilter="전체"

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -167,11 +167,7 @@ const HomePage = () => {
   }, []);
 
   const handleBookmarkChange = useCallback((specId, isBookmarked) => {
-    setRankingData((prevData) =>
-      prevData.map((item) =>
-        item.specId === specId ? { ...item, isBookmarked } : item
-      )
-    );
+    // 전역 스토어에서 상태가 자동으로 업데이트되므로 추가 작업 불필요
   }, []);
 
   const handleRetry = () => {
@@ -252,7 +248,6 @@ const HomePage = () => {
               usersCountByJobField={item.usersCountByJobField}
               score={item.score}
               jobField={item.jobField}
-              isBookmarked={item.isBookmarked}
               commentsCount={item.commentsCount}
               bookmarksCount={item.bookmarksCount}
               selectedFilter={selectedFilter}

--- a/src/pages/RankingPage.jsx
+++ b/src/pages/RankingPage.jsx
@@ -188,7 +188,6 @@ const RankingPage = () => {
         jobField: jobField,
         rankByJobField: 1,
         totalUsersCountByJobField: 50,
-        isBookmarked: true,
         commentsCount: 57,
         bookmarksCount: 243,
       },
@@ -203,7 +202,6 @@ const RankingPage = () => {
         jobField: jobField,
         rankByJobField: 2,
         totalUsersCountByJobField: 50,
-        isBookmarked: false,
         commentsCount: 42,
         bookmarksCount: 120,
       },
@@ -218,7 +216,6 @@ const RankingPage = () => {
         jobField: jobField,
         rankByJobField: 3,
         totalUsersCountByJobField: 50,
-        isBookmarked: true,
         commentsCount: 35,
         bookmarksCount: 98,
       },
@@ -233,7 +230,6 @@ const RankingPage = () => {
         jobField: jobField,
         rankByJobField: 4,
         totalUsersCountByJobField: 50,
-        isBookmarked: false,
         commentsCount: 28,
         bookmarksCount: 76,
       },
@@ -248,7 +244,6 @@ const RankingPage = () => {
         jobField: jobField,
         rankByJobField: 5,
         totalUsersCountByJobField: 50,
-        isBookmarked: true,
         commentsCount: 21,
         bookmarksCount: 65,
       },
@@ -411,11 +406,7 @@ const RankingPage = () => {
   };
 
   const handleBookmarkChange = useCallback((specId, isBookmarked) => {
-    setRankings((prevRankings) =>
-      prevRankings.map((ranking) =>
-        ranking.specId === specId ? { ...ranking, isBookmarked } : ranking
-      )
-    );
+    // 전역 스토어에서 상태가 자동으로 업데이트되므로 추가 작업 불필요
   }, []);
 
   // 초기 랭킹 데이터 로드
@@ -595,7 +586,6 @@ const RankingPage = () => {
                           usersCountByJobField={ranking.usersCountByJobField}
                           score={ranking.score}
                           jobField={ranking.jobField}
-                          isBookmarked={ranking.isBookmarked}
                           commentsCount={ranking.commentsCount}
                           bookmarksCount={ranking.bookmarksCount}
                           onBookmarkChange={handleBookmarkChange}

--- a/src/pages/RankingResultPage.jsx
+++ b/src/pages/RankingResultPage.jsx
@@ -125,11 +125,7 @@ const RankingResultPage = () => {
   );
 
   const handleBookmarkChange = useCallback((specId, isBookmarked) => {
-    setSearchResults((prevData) =>
-      prevData.map((item) =>
-        item.specId === specId ? { ...item, isBookmarked } : item
-      )
-    );
+    // 전역 스토어에서 상태가 자동으로 업데이트되므로 추가 작업 불필요
   }, []);
 
   // 컴포넌트 마운트 시 초기 데이터 로드
@@ -259,7 +255,6 @@ const RankingResultPage = () => {
                         usersCountByJobField={result.totalUsersCountByJobField}
                         score={result.score}
                         jobField={result.jobField}
-                        isBookmarked={result.isBookmarked}
                         commentsCount={result.commentsCount}
                         bookmarksCount={result.bookmarksCount}
                         onBookmarkChange={handleBookmarkChange}

--- a/src/pages/SocialPage.jsx
+++ b/src/pages/SocialPage.jsx
@@ -5,7 +5,7 @@ import { BarChart3, FileText } from 'lucide-react';
 import SocialProfileCard from '../components/user/profile/SocialProfileCard';
 import RadarChart from '../components/spec-analysis/RadarChart';
 import SpecDetailInfo from '../components/spec-analysis/SpecDetailTab';
-import { SpecAPI, UserAPI, BookmarkAPI, ChatAPI } from '../api';
+import { SpecAPI, UserAPI, ChatAPI } from '../api';
 import CommentsSection from '../components/comment/CommentsSection';
 
 const SocialPage = () => {
@@ -20,7 +20,6 @@ const SocialPage = () => {
   const [hasSpec, setHasSpec] = useState(false);
   const [specData, setSpecData] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [isBookmarked, setIsBookmarked] = useState(false);
   const [activeTab, setActiveTab] = useState('analysis');
   const [currentSpecId, setCurrentSpecId] = useState(null);
   const [accessDenied, setAccessDenied] = useState(false);
@@ -48,22 +47,6 @@ const SocialPage = () => {
   }, [specId, userId, currentUser]);
 
   // loadPageData 함수에서 타인 페이지 처리 부분에 추가
-  const checkBookmarkStatus = async (specId) => {
-    try {
-      const bookmarkResponse = await BookmarkAPI.getBookmarks({ cursor: null });
-      if (bookmarkResponse.data.isSuccess) {
-        const bookmarks = bookmarkResponse.data.data.bookmarks;
-        return bookmarks.some(
-          (bookmark) => bookmark.spec.id === parseInt(specId)
-        );
-      }
-      return false;
-    } catch (error) {
-      console.error('즐겨찾기 상태 확인 실패:', error);
-      return false;
-    }
-  };
-
   const loadPageData = async () => {
     try {
       setLoading(true);
@@ -228,8 +211,6 @@ const SocialPage = () => {
             }
 
             setUserData(profileData);
-            const bookmarkStatus = await checkBookmarkStatus(specId);
-            setIsBookmarked(bookmarkStatus);
           } else {
             console.error('스펙 정보 조회 실패:', specResponse.data?.message);
             throw new Error('스펙 정보를 불러올 수 없습니다.');
@@ -296,7 +277,7 @@ const SocialPage = () => {
 
   const handleBookmarkChange = useCallback(
     (specId, isBookmarked, bookmarkId) => {
-      setIsBookmarked(isBookmarked);
+      // 전역 스토어에서 상태가 자동으로 업데이트되므로 추가 작업 불필요
     },
     []
   );
@@ -326,7 +307,6 @@ const SocialPage = () => {
           showButtons={!isMyPage}
           onDMClick={handleDMClick}
           onFavoriteClick={handleBookmarkChange}
-          isFavorite={isBookmarked}
           specId={specId}
         />
 

--- a/src/stores/useAuthStore.js
+++ b/src/stores/useAuthStore.js
@@ -93,6 +93,14 @@ export const useAuthStore = create((set, get) => ({
     removeAccessToken();
     HttpAPI.setAuthToken(null);
     set({ isLoggedIn: false, user: null, token: null, loading: false });
+
+    // 즐겨찾기 스토어도 초기화
+    try {
+      const { useBookmarkStore } = require('./useBookmarkStore');
+      useBookmarkStore.getState().reset();
+    } catch (error) {
+      console.error('즐겨찾기 스토어 초기화 실패:', error);
+    }
   },
 
   /** 유저 정보 업데이트 */

--- a/src/stores/useBookmarkStore.js
+++ b/src/stores/useBookmarkStore.js
@@ -1,0 +1,154 @@
+import { create } from 'zustand';
+import { BookmarkAPI } from '../api';
+
+export const useBookmarkStore = create((set, get) => ({
+  // 즐겨찾기된 스펙 ID들의 Set
+  bookmarkedSpecIds: new Set(),
+  // 즐겨찾기 ID 매핑 (specId -> bookmarkId)
+  bookmarkIdMap: new Map(),
+  // 로딩 상태
+  loading: false,
+  // 초기화 완료 여부
+  initialized: false,
+
+  // 즐겨찾기 상태 초기화
+  initializeBookmarks: async () => {
+    const { setLoading, setInitialized } = get();
+
+    try {
+      setLoading(true);
+      const response = await BookmarkAPI.getBookmarks({
+        cursor: null,
+        limit: 1000,
+      });
+
+      if (response.data.isSuccess) {
+        const bookmarks = response.data.data.bookmarks;
+        const bookmarkedSpecIds = new Set();
+        const bookmarkIdMap = new Map();
+
+        bookmarks.forEach((bookmark) => {
+          const specId = bookmark.spec.id;
+          bookmarkedSpecIds.add(specId);
+          bookmarkIdMap.set(specId, bookmark.id);
+        });
+
+        set({
+          bookmarkedSpecIds,
+          bookmarkIdMap,
+          initialized: true,
+        });
+      }
+    } catch (error) {
+      console.error('즐겨찾기 초기화 실패:', error);
+      set({ initialized: true });
+    } finally {
+      setLoading(false);
+    }
+  },
+
+  // 즐겨찾기 등록
+  addBookmark: async (specId) => {
+    const { bookmarkedSpecIds, bookmarkIdMap, setBookmarkState } = get();
+
+    try {
+      const response = await BookmarkAPI.addBookmark(specId);
+
+      if (response.data?.isSuccess) {
+        const bookmarkId = response.data.data?.bookmarkId;
+
+        const newBookmarkedSpecIds = new Set(bookmarkedSpecIds);
+        newBookmarkedSpecIds.add(specId);
+
+        const newBookmarkIdMap = new Map(bookmarkIdMap);
+        newBookmarkIdMap.set(specId, bookmarkId);
+
+        set({
+          bookmarkedSpecIds: newBookmarkedSpecIds,
+          bookmarkIdMap: newBookmarkIdMap,
+        });
+
+        return { success: true, bookmarkId };
+      }
+
+      return { success: false, message: response.data?.message };
+    } catch (error) {
+      console.error('즐겨찾기 등록 실패:', error);
+      return { success: false, message: '즐겨찾기 등록에 실패했습니다.' };
+    }
+  },
+
+  // 즐겨찾기 해제
+  removeBookmark: async (specId) => {
+    const { bookmarkedSpecIds, bookmarkIdMap } = get();
+
+    try {
+      const response = await BookmarkAPI.removeBookmark(specId);
+
+      if (response.status === 204 || response.data?.isSuccess) {
+        const newBookmarkedSpecIds = new Set(bookmarkedSpecIds);
+        newBookmarkedSpecIds.delete(specId);
+
+        const newBookmarkIdMap = new Map(bookmarkIdMap);
+        newBookmarkIdMap.delete(specId);
+
+        set({
+          bookmarkedSpecIds: newBookmarkedSpecIds,
+          bookmarkIdMap: newBookmarkIdMap,
+        });
+
+        return { success: true };
+      }
+
+      return { success: false, message: response.data?.message };
+    } catch (error) {
+      console.error('즐겨찾기 해제 실패:', error);
+      return { success: false, message: '즐겨찾기 해제에 실패했습니다.' };
+    }
+  },
+
+  // 특정 스펙의 즐겨찾기 상태 확인
+  isBookmarked: (specId) => {
+    const { bookmarkedSpecIds } = get();
+    return bookmarkedSpecIds.has(specId);
+  },
+
+  // 특정 스펙의 즐겨찾기 ID 가져오기
+  getBookmarkId: (specId) => {
+    const { bookmarkIdMap } = get();
+    return bookmarkIdMap.get(specId);
+  },
+
+  // 즐겨찾기된 스펙 개수
+  getBookmarkCount: () => {
+    const { bookmarkedSpecIds } = get();
+    return bookmarkedSpecIds.size;
+  },
+
+  // 즐겨찾기 상태 토글
+  toggleBookmark: async (specId) => {
+    const { isBookmarked, addBookmark, removeBookmark } = get();
+
+    if (isBookmarked(specId)) {
+      return await removeBookmark(specId);
+    } else {
+      return await addBookmark(specId);
+    }
+  },
+
+  // 스토어 초기화
+  reset: () => {
+    set({
+      bookmarkedSpecIds: new Set(),
+      bookmarkIdMap: new Map(),
+      loading: false,
+      initialized: false,
+    });
+  },
+
+  // 로딩 상태 설정
+  setLoading: (loading) => set({ loading }),
+
+  // 초기화 상태 설정
+  setInitialized: (initialized) => set({ initialized }),
+}));


### PR DESCRIPTION
## ☝️ 요약
즐겨찾기 상태 props 전달 방식에서 전역 상태 관리로 변경

<br/>

## ✏️ 상세 내용
- 즐겨찾기 상태 관리 방식 변경
  - 기존 : props 값으로 전달
  - 수정 : zustand 활용해 useBookmarkStore로 전역 상태 관리

- useBookmarkStore 생성하고 그 안에서 BookmarkAPI 호출
- RankingItem 컴포넌트와 ProfileCard 컴포넌트에서 useBookmarkStore 활용
  - RankingItem 활용하는 페이지 : HomePage, RankingPage, RankingResultPage, BookmarkPage
  - ProfileCard 활용하는 페이지 : SocialPage  

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.
- [x] 로컬 테스트 완료했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)
#88 

<br/>

## 비고 (선택)