### PR TITLE
fix: 쿠키 도메인을 .specranking.net으로 변경

### DIFF
--- a/src/constants/domains.js
+++ b/src/constants/domains.js
@@ -1,7 +1,7 @@
 const isLocal = false;
 
 export const DOMAINS = {
-  COOKIE_DOMAIN: isLocal ? 'localhost' : '.dev.specranking.net', // 서브도메인 포함 쿠키용
+  COOKIE_DOMAIN: isLocal ? 'localhost' : '.specranking.net', // 서브도메인 포함 쿠키용
 
   FRONTEND_DOMAIN: isLocal ? 'localhost:3000' : 'dev.specranking.net',
 


### PR DESCRIPTION
## ☝️ 요약
쿠키 도메인을 .specranking.net으로 변경

<br/>

## ✏️ 상세 내용
- 프론트엔드 도메인: `dev.specranking.net` / 백엔드 도메인: `api.dev.specranking.net`
- 서브 도메인 접근이 막혀서 백엔드에서 받은 쿠키가 제대로 인식되지 않는 것으로 예상됨
- 두 도메인에 대한 접근을 모두 허용하도록 도메인명 수정함

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)