### PR TITLE
fix: 렌더링 문제 해결, 로그인 두 번 시도해야 성공하는 문제 해결 시도, 디자인 수정

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -88,3 +88,8 @@ main {
   scrollbar-width: thin;
   scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
 }
+
+/* 레이아웃 컨테이너 그림자 */
+.layout-container {
+  box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -148,7 +148,7 @@ const Layout = ({ children }) => {
   const isChatPage = path === '/chat';
 
   return (
-    <div className="relative w-full max-w-[390px] mx-auto min-h-screen bg-gray-50 shadow-2xl">
+    <div className="relative w-full max-w-[390px] mx-auto min-h-screen bg-gray-50 layout-container">
       <TopBar title={getTitleByPath()} backLink={getBackButtonConfig()} />
       <main
         className={`${isChatPage ? '' : 'pt-14 pb-16'} min-h-[calc(100vh-120px)]`}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -130,7 +130,7 @@ const Layout = ({ children }) => {
   const getActiveMenu = () => {
     if (path === '/') return 'home';
     if (path === '/rank' || path === 'ranking-results') return 'rank';
-    if (path === '/chatrooms') return 'dm';
+    if (path === '/chatrooms' || path === '/chat') return 'dm';
     if (path === '/social' || path.startsWith('/social/')) return 'social';
     if (
       path === '/my' ||

--- a/src/components/ServiceIntro.jsx
+++ b/src/components/ServiceIntro.jsx
@@ -1,15 +1,20 @@
 import React from 'react';
 
 const ServiceIntro = () => {
-    return (
-      <div className="p-4 mb-4 rounded-lg bg-blue-50">
-        <h3 className="mb-2 font-semibold">스펙랭킹 서비스란?</h3>
-        <p className="text-sm text-gray-700">
-          당신의 스펙을 다른 사람들과 비교하여 객관적인 경쟁력을 확인할 수 있는 서비스입니다. 
-          경력, 학력, 자격증, 프로젝트 경험 등을 종합적으로 평가하여 나의 위치를 실시간 랭킹으로 보여줍니다.
-        </p>
-      </div>
-    );
-  };
+  return (
+    <div className="p-4 mb-4 rounded-lg bg-blue-50 shadow-md">
+      <h3 className="mb-2 font-semibold">스펙랭킹 서비스란?</h3>
+      <p className="text-sm text-gray-700">
+        당신의 스펙을 다른 사용자들의 스펙과 비교하여{' '}
+        <span className="font-bold text-blue-700">객관적인 경쟁력</span>을
+        확인할 수 있는 서비스입니다.
+        <span className="font-bold text-blue-700"> AI 모델</span> 기반으로 경력,
+        학력, 자격증, 프로젝트 경험 등을 종합적으로 평가하여 나의 위치를{' '}
+        <span className="font-bold text-blue-700">실시간 랭킹</span>으로
+        보여줍니다.
+      </p>
+    </div>
+  );
+};
 
-  export default ServiceIntro;
+export default ServiceIntro;

--- a/src/components/common/Toast.jsx
+++ b/src/components/common/Toast.jsx
@@ -79,7 +79,7 @@ const Toast = ({
   return (
     <div className={getToastStyles()}>
       {getIcon()}
-      <span className="flex-1 font-medium">{message}</span>
+      <span className="flex-1 font-medium whitespace-pre-line">{message}</span>
       <button
         onClick={handleClose}
         className="flex-shrink-0 ml-3 text-gray-400 transition-colors duration-200 hover:text-gray-600"

--- a/src/components/user/UserInfoSection.jsx
+++ b/src/components/user/UserInfoSection.jsx
@@ -3,6 +3,7 @@ import { Brain } from 'lucide-react';
 import HomeProfileCard from './profile/HomeProfileCard';
 import SpecBars from '../spec-analysis/SpecBars';
 import AIInsights from '../spec-analysis/AIInsights';
+import { PageLoadingIndicator } from '../common/LoadingIndicator';
 
 const UserInfoSection = ({
   userData,
@@ -59,26 +60,59 @@ const UserInfoSection = ({
     }
   }, [isLoggedIn, hasSpec, userData, categoryScores]);
 
-  // 스펙이 없거나 로그인하지 않은 경우 기본 프로필 카드만 표시
-  if (!isLoggedIn || !hasSpec || categoryScores.length === 0) {
+  // ✅ 로그인하지 않은 경우 바로 LoginPrompt로 빠지기
+  if (!isLoggedIn) {
     return (
-      <HomeProfileCard
-        userData={userData}
-        isLoggedIn={isLoggedIn}
-        hasSpec={hasSpec}
-      />
+      <HomeProfileCard userData={userData} isLoggedIn={false} hasSpec={false} />
     );
   }
 
-  // 로그인하고 스펙이 있는 경우 AI 분석 포함
+  // ✅ 로그인은 했지만 아직 userData를 못 받았거나 스펙 여부 판단 중이면 로딩 UI
+  if (userData === null || hasSpec === null) {
+    return (
+      <div className="flex-1 p-4 pb-20">
+        <div className="p-6 mb-4 bg-white rounded-lg shadow">
+          <div className="flex items-center space-x-4 animate-pulse">
+            <div className="w-12 h-12 bg-gray-200 rounded-lg"></div>
+            <div className="flex-1 space-y-2">
+              <div className="w-1/4 h-4 bg-gray-200 rounded"></div>
+              <div className="w-1/2 h-3 bg-gray-200 rounded"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ✅ 로그인은 했지만 스펙이 없는 경우
+  if (!hasSpec) {
+    return (
+      <HomeProfileCard userData={userData} isLoggedIn={true} hasSpec={false} />
+    );
+  }
+
+  // ✅ 로그인 + 스펙 존재 + 분석점수 있음
+  if (categoryScores.length === 0) {
+    return (
+      <div className="flex-1 p-4 pb-20">
+        <div className="p-6 mb-4 bg-white rounded-lg shadow">
+          <div className="flex items-center space-x-4 animate-pulse">
+            <div className="w-12 h-12 bg-gray-200 rounded-lg"></div>
+            <div className="flex-1 space-y-2">
+              <div className="w-1/4 h-4 bg-gray-200 rounded"></div>
+              <div className="w-1/2 h-3 bg-gray-200 rounded"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ✅ 최종 분석 화면
   return (
     <div className="w-full mb-4 bg-white border border-gray-100 shadow-sm rounded-2xl">
       <div className="p-4">
-        <HomeProfileCard
-          userData={userData}
-          isLoggedIn={isLoggedIn}
-          hasSpec={hasSpec}
-        />
+        <HomeProfileCard userData={userData} isLoggedIn={true} hasSpec={true} />
       </div>
 
       <div className="p-5 border-t border-gray-200">

--- a/src/components/user/profile/HomeProfileCard.jsx
+++ b/src/components/user/profile/HomeProfileCard.jsx
@@ -4,46 +4,44 @@ import SpecInputPrompt from './SpecInputPrompt';
 import ProfileCard from './ProfileCard';
 
 const HomeProfileCard = ({ userData, isLoggedIn = false, hasSpec = false }) => {
+  let content;
+
   // 로그인하지 않은 경우
   if (!isLoggedIn) {
-    return <LoginPrompt />;
-  }
-
-  // 로그인했지만 스펙이 없는 경우
-  if (!hasSpec) {
-    return <SpecInputPrompt userData={userData} />;
-  }
-
-  if (!userData) {
-    return (
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 max-w-sm">
-        <div className="animate-pulse flex items-center space-x-3">
+    content = <LoginPrompt />;
+  } else if (!hasSpec) {
+    content = <SpecInputPrompt userData={userData} />;
+  } else if (!userData) {
+    content = (
+      <div className="max-w-sm p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
+        <div className="flex items-center space-x-3 animate-pulse">
           <div className="w-12 h-12 bg-gray-200 rounded-lg"></div>
           <div className="flex-1 space-y-2">
-            <div className="h-4 bg-gray-200 rounded w-1/4"></div>
-            <div className="h-3 bg-gray-200 rounded w-1/2"></div>
+            <div className="w-1/4 h-4 bg-gray-200 rounded"></div>
+            <div className="w-1/2 h-3 bg-gray-200 rounded"></div>
           </div>
         </div>
       </div>
     );
+  } else {
+    content = (
+      <ProfileCard
+        profileImageUrl={userData.profileImageUrl}
+        nickname={userData.nickname}
+        jobField={userData.jobField}
+        totalScore={userData.totalScore}
+        totalRank={userData.totalRank}
+        totalRankPercent={userData.totalRankPercent}
+        jobFieldRank={userData.jobFieldRank}
+        jobFieldRankPercent={userData.jobFieldRankPercent}
+        totalUsers={userData.totalUsers}
+        jobFieldUsers={userData.jobFieldUsers}
+        showRanking={true}
+      />
+    );
   }
 
-  // 로그인하고 스펙이 있는 경우
-  return (
-    <ProfileCard
-      profileImageUrl={userData.profileImageUrl}
-      nickname={userData.nickname}
-      jobField={userData.jobField}
-      totalScore={userData.totalScore}
-      totalRank={userData.totalRank}
-      totalRankPercent={userData.totalRankPercent}
-      jobFieldRank={userData.jobFieldRank}
-      jobFieldRankPercent={userData.jobFieldRankPercent}
-      totalUsers={userData.totalUsers}
-      jobFieldUsers={userData.jobFieldUsers}
-      showRanking={true}
-    />
-  );
+  return <>{content}</>;
 };
 
 export default HomeProfileCard;

--- a/src/components/user/profile/SocialProfileCard.jsx
+++ b/src/components/user/profile/SocialProfileCard.jsx
@@ -10,6 +10,8 @@ const SocialProfileCard = ({
   onFavoriteClick,
   specId,
 }) => {
+  if (!userData) return null;
+
   // 스펙이 없는 경우
   if (!hasSpec) {
     return (

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -187,7 +187,7 @@ const HomePage = () => {
             </div>
           </div>
         </div>
-        <PageLoadingIndicator />
+        <PageLoadingIndicator className="hidden" />
       </div>
     );
   }

--- a/src/pages/OAuthRedirectPage.jsx
+++ b/src/pages/OAuthRedirectPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../stores/useAuthStore';
 import { getCookie, deleteCookie } from '../utils/cookie';
@@ -6,7 +6,8 @@ import { DOMAINS } from '../constants/domains';
 
 const OAuthRedirectPage = () => {
   const navigate = useNavigate();
-  const { login } = useAuthStore();
+  const { login, isLoggedIn } = useAuthStore();
+  const [loginAttempted, setLoginAttempted] = useState(false);
 
   useEffect(() => {
     const tempLoginId = getCookie('TempLoginId');
@@ -16,24 +17,37 @@ const OAuthRedirectPage = () => {
       navigate('/profile-setup');
       return;
     }
-    if (authorization) {
+
+    if (authorization && !loginAttempted) {
+      console.log('로그인 시도 시작');
+      setLoginAttempted(true);
+
       login(null, authorization);
+
       deleteCookie('access', '/', DOMAINS.COOKIE_DOMAIN);
-
-      setTimeout(() => {
-        window.location.href = '/';
-      }, 200);
-
       return;
     }
 
-    console.log('로그인 실패: Authorization, TempLoginId 둘 다 존재 X');
-    navigate('/login');
-  }, [navigate, login]);
+    if (!authorization && !tempLoginId) {
+      console.log('로그인 실패: Authorization, TempLoginId 둘 다 존재 X');
+      navigate('/login');
+    }
+  }, [navigate, login, loginAttempted]);
+
+  useEffect(() => {
+    if (loginAttempted && isLoggedIn) {
+      console.log('로그인 완료 확인, 홈페이지로 이동');
+      setTimeout(() => {
+        window.location.href = '/';
+      }, 100);
+    }
+  }, [isLoggedIn, loginAttempted]);
 
   return (
     <div className="flex items-center justify-center min-h-screen">
-      <p className="text-gray-600">처리 중입니다...</p>
+      <p className="text-gray-600">
+        {loginAttempted ? '로그인 처리 중입니다...' : '처리 중입니다...'}
+      </p>
     </div>
   );
 };

--- a/src/pages/RankingPage.jsx
+++ b/src/pages/RankingPage.jsx
@@ -527,7 +527,7 @@ const RankingPage = () => {
           />
 
           {/* 메타 데이터 (총 사용자 수, 평균 점수) */}
-          <div className="mb-6">
+          <div className="mb-2">
             <div className="flex rounded-lg bg-blue-50">
               <div className="flex-1 p-4 text-center">
                 <div className="mb-1 text-sm text-gray-500">총 사용자</div>
@@ -563,7 +563,7 @@ const RankingPage = () => {
                   <p>랭킹 데이터가 없습니다.</p>
                 </div>
               ) : (
-                <div className="space-y-4">
+                <div>
                   {rankings.map((ranking, index) => {
                     return (
                       <div

--- a/src/pages/RankingResultPage.jsx
+++ b/src/pages/RankingResultPage.jsx
@@ -233,7 +233,7 @@ const RankingResultPage = () => {
                   </p>
                 </div>
               ) : (
-                <div className="space-y-4">
+                <div>
                   {searchResults.map((result, index) => (
                     <div
                       key={`${result.userId}_${index}`}

--- a/src/pages/SocialPage.jsx
+++ b/src/pages/SocialPage.jsx
@@ -7,6 +7,7 @@ import RadarChart from '../components/spec-analysis/RadarChart';
 import SpecDetailInfo from '../components/spec-analysis/SpecDetailTab';
 import { SpecAPI, UserAPI, ChatAPI } from '../api';
 import CommentsSection from '../components/comment/CommentsSection';
+import { PageLoadingIndicator } from '../components/common/LoadingIndicator';
 
 const SocialPage = () => {
   const { specId } = useParams();
@@ -212,10 +213,12 @@ const SocialPage = () => {
             setUserData(profileData);
           } else {
             console.error('스펙 정보 조회 실패:', specResponse.data?.message);
+            setAccessDenied(true);
             throw new Error('스펙 정보를 불러올 수 없습니다.');
           }
         } else {
           console.error('사용자 정보 조회 실패:', userResponse.data?.message);
+          setAccessDenied(true);
           throw new Error('사용자 정보를 불러올 수 없습니다.');
         }
       }
@@ -283,18 +286,23 @@ const SocialPage = () => {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-gray-500">로딩 중...</div>
+      <div className="flex items-center justify-center min-h-screen">
+        <PageLoadingIndicator />
       </div>
     );
   }
 
-  if (!userData) {
+  if (accessDenied) {
     return (
       <div className="flex items-center justify-center h-64">
         <div className="text-gray-500">사용자 정보를 불러올 수 없습니다.</div>
       </div>
     );
+  }
+
+  // userData가 없으면 아무것도 렌더링하지 않음 (로딩 끝났지만 데이터가 없는 경우 방지)
+  if (!userData) {
+    return null;
   }
 
   return (

--- a/src/pages/SpecInputPage.jsx
+++ b/src/pages/SpecInputPage.jsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import { UserAPI, SpecAPI } from '../api';
 import { useAuthStore } from '../stores/useAuthStore';
 import { getAccessToken } from '../utils/token';
+import useToast from '../hooks/useToast';
+import ToastContainer from '../components/common/ToastContainer';
 
 // 상수 데이터 정의
 const JOB_FIELDS = [
@@ -17,44 +19,18 @@ const JOB_FIELDS = [
   '연구개발_설계',
   '디자인',
   '미디어',
-  '전문직_특수직'
+  '전문직_특수직',
 ];
 
-const INSTITUTES = [
-  '중학교',
-  '고등학교',
-  '2_3년 대학교',
-  '대학교',
-  '대학원'
-];
+const INSTITUTES = ['중학교', '고등학교', '2_3년 대학교', '대학교', '대학원'];
 
-const EDUCATION_STATUS = [
-  '졸업',
-  '수료',
-  '중퇴',
-  '휴학',
-  '재학'
-];
+const EDUCATION_STATUS = ['졸업', '수료', '중퇴', '휴학', '재학'];
 
-const DEGREE_TYPES = [
-  '박사',
-  '석사',
-  '학사',
-  '전문학사',
-  '수료'
-];
+const DEGREE_TYPES = ['박사', '석사', '학사', '전문학사', '수료'];
 
-const GPA_SCALE = [
-  '4.3',
-  '4.5',
-  '4.0'
-];
+const GPA_SCALE = ['4.3', '4.5', '4.0'];
 
-const POSITIONS = [
-  '대표',
-  '정규직',
-  '인턴'
-];
+const POSITIONS = ['대표', '정규직', '인턴'];
 
 const LANGUAGE_TESTS = [
   { value: 'TOEIC_ENGLISH', label: 'TOEIC(영어)' },
@@ -85,7 +61,7 @@ const LANGUAGE_TESTS = [
   { value: 'OPIC_RUSSIAN', label: 'OPIC(러시아어)' },
   { value: 'OPIC_SPANISH', label: 'OPIC(스페인어)' },
   { value: 'OPIC_JAPANESE', label: 'OPIC(일본어)' },
-  { value: 'OPIC_VIETNAMESE', label: 'OPIC(베트남어)' }
+  { value: 'OPIC_VIETNAMESE', label: 'OPIC(베트남어)' },
 ];
 
 const SpecInputPage = () => {
@@ -103,29 +79,31 @@ const SpecInputPage = () => {
   const fileInputRef = useRef(null); // 파일 입력 참조
   const [fileErrorMessage, setFileErrorMessage] = useState(null);
   const [showFileErrorModal, setShowFileErrorModal] = useState(false);
-  
+
+  const { toasts, showToast, removeToast } = useToast();
+
   // Handlers for cancel confirmation
   const handleCancelAttempt = () => setShowConfirmModal(true);
   const handleConfirmCancel = () => navigate('/my');
   const handleCloseModal = () => setShowConfirmModal(false);
-  
+
   // 에러 메시지를 닫는 함수 추가
   const clearError = () => {
     setError(null);
   };
-  
+
   const [formData, setFormData] = useState({
     name: '', // 사용자 닉네임(수정 불가)
     finalEducation: {
       institute: '대학교',
-      status: '졸업'
+      status: '졸업',
     },
     educationDetails: [], // 초기에 빈 배열로 시작 - 학교, 전공, 학위, 학점 정보
     workExperiences: [], // 초기에 빈 배열로 시작
     certifications: [], // 초기에 빈 배열로 시작
     languageSkills: [], // 초기에 빈 배열로 시작
     activities: [], // 초기에 빈 배열로 시작 - 활동/네트워킹
-    jobField: '인터넷_IT'
+    jobField: '인터넷_IT',
   });
 
   // 컴포넌트 마운트 시 유저 정보와 스펙 정보 가져오기
@@ -133,7 +111,7 @@ const SpecInputPage = () => {
     const fetchUserAndSpecData = async () => {
       try {
         setLoading(true);
-        
+
         const token = getAccessToken();
         if (!token) {
           console.log('토큰이 없어 로그인 페이지로 이동합니다.');
@@ -157,65 +135,68 @@ const SpecInputPage = () => {
           navigate('/login');
           return;
         }
-       
-        
+
         // 유저 정보 가져오기
         const userResponse = await UserAPI.getUserInfo(authUser.id);
-        
+
         if (userResponse.data.isSuccess) {
           const userData = userResponse.data.data.user;
-          
+
           // 사용자 이름을 폼 데이터에 설정
-          setFormData(prev => ({
+          setFormData((prev) => ({
             ...prev,
             name: userData.nickname,
-            jobField: userData.jobField || '인터넷_IT'
+            jobField: userData.jobField || '인터넷_IT',
           }));
-          
+
           // 활성화된 스펙이 있는지 확인
           if (userData.spec && userData.spec.hasActiveSpec) {
             setIsEditMode(true);
             setActiveSpecId(userData.spec.activeSpec);
-            
+
             // 활성화된 스펙 정보 가져오기
-            const specResponse = await SpecAPI.getSpecDetail(userData.spec.activeSpec);
-            
+            const specResponse = await SpecAPI.getSpecDetail(
+              userData.spec.activeSpec
+            );
+
             if (specResponse.data.isSuccess) {
               const specData = specResponse.data.specDetailData;
-              
+
               // 가져온 스펙 정보로 폼 데이터 업데이트
-              setFormData(prev => ({
+              setFormData((prev) => ({
                 ...prev,
                 name: userData.nickname,
                 finalEducation: {
                   institute: specData.finalEducation.institute,
-                  status: specData.finalEducation.status || specData.finalEducation.finalStatus // status 또는 finalStatus 필드 사용
+                  status:
+                    specData.finalEducation.status ||
+                    specData.finalEducation.finalStatus, // status 또는 finalStatus 필드 사용
                 },
-                educationDetails: specData.educationDetails.map(edu => ({
+                educationDetails: specData.educationDetails.map((edu) => ({
                   schoolName: edu.schoolName,
                   degree: edu.degree,
                   major: edu.major,
                   gpa: edu.gpa.toString(),
-                  maxGpa: edu.maxGpa.toString()
+                  maxGpa: edu.maxGpa.toString(),
                 })),
-                workExperiences: specData.workExperiences.map(exp => ({
+                workExperiences: specData.workExperiences.map((exp) => ({
                   companyName: exp.companyName || exp.company, // companyName 또는 company 필드 사용
                   position: exp.position,
-                  period: exp.period.toString()
+                  period: exp.period.toString(),
                 })),
-                certifications: specData.certifications.map(cert => ({
-                  name: cert.name
+                certifications: specData.certifications.map((cert) => ({
+                  name: cert.name,
                 })),
-                languageSkills: specData.languageSkills.map(lang => ({
+                languageSkills: specData.languageSkills.map((lang) => ({
                   languageTest: lang.languageTest || lang.name, // languageTest 또는 name 필드 사용
-                  score: lang.score
+                  score: lang.score,
                 })),
-                activities: specData.activities.map(activity => ({
+                activities: specData.activities.map((activity) => ({
                   name: activity.name,
                   role: activity.role,
-                  award: activity.award || ''
+                  award: activity.award || '',
                 })),
-                jobField: specData.jobField || userData.jobField || '인터넷_IT'
+                jobField: specData.jobField || userData.jobField || '인터넷_IT',
               }));
             }
           }
@@ -228,25 +209,25 @@ const SpecInputPage = () => {
         setLoading(false);
       }
     };
-    
+
     // 페이지 로드 시 항상 데이터 가져오기
     fetchUserAndSpecData();
-    
+
     // 브라우저 뒤로가기 및 페이지 복원 시 데이터 새로 로드
     const handlePopState = () => {
       window.location.reload(); // 브라우저 뒤로가기 시 페이지 강제 새로고침
     };
-    
+
     const handlePageShow = (event) => {
       if (event.persisted) {
         window.location.reload(); // bfcache에서 페이지 복원 시 강제 새로고침
       }
     };
-    
+
     // 이벤트 리스너 등록
     window.addEventListener('popstate', handlePopState);
     window.addEventListener('pageshow', handlePageShow);
-    
+
     // 컴포넌트 언마운트 시 이벤트 리스너 제거
     return () => {
       window.removeEventListener('popstate', handlePopState);
@@ -255,19 +236,19 @@ const SpecInputPage = () => {
   }, []);
 
   const handleInputChange = (field, value) => {
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
-      [field]: value
+      [field]: value,
     }));
   };
 
   const handleNestedInputChange = (mainField, subField, value) => {
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
       [mainField]: {
         ...prev[mainField],
-        [subField]: value
-      }
+        [subField]: value,
+      },
     }));
   };
 
@@ -277,41 +258,41 @@ const SpecInputPage = () => {
       console.error(`Field ${field} is not an array`);
       return;
     }
-    
+
     const newArray = [...formData[field]];
     // 인덱스가 유효한지 확인
     if (index >= 0 && index < newArray.length) {
       newArray[index] = {
         ...newArray[index],
-        [subField]: value
+        [subField]: value,
       };
-      
-      setFormData(prev => ({
+
+      setFormData((prev) => ({
         ...prev,
-        [field]: newArray
+        [field]: newArray,
       }));
     }
   };
 
   const addArrayItem = (field, template) => {
-    setFormData(prev => {
+    setFormData((prev) => {
       // 필드가 존재하고 배열인지 확인
       const currentField = Array.isArray(prev[field]) ? prev[field] : [];
       return {
         ...prev,
-        [field]: [...currentField, {...template}]
+        [field]: [...currentField, { ...template }],
       };
     });
   };
 
   const removeArrayItem = (field, index) => {
-    setFormData(prev => {
+    setFormData((prev) => {
       // 필드가 존재하고 배열인지 확인
       const currentField = Array.isArray(prev[field]) ? prev[field] : [];
       // 모든 항목 삭제 허용 (마지막 항목도 삭제 가능)
       return {
         ...prev,
-        [field]: currentField.filter((_, i) => i !== index)
+        [field]: currentField.filter((_, i) => i !== index),
       };
     });
   };
@@ -333,7 +314,7 @@ const SpecInputPage = () => {
       for (let i = 0; i < formData.educationDetails.length; i++) {
         const edu = formData.educationDetails[i];
         if (!edu.schoolName || !edu.major || !edu.gpa) {
-          setError(`${i+1}번째 학력 정보의 모든 필드를 입력해주세요.`);
+          setError(`${i + 1}번째 학력 정보의 모든 필드를 입력해주세요.`);
           return false;
         }
       }
@@ -344,7 +325,7 @@ const SpecInputPage = () => {
       for (let i = 0; i < formData.workExperiences.length; i++) {
         const exp = formData.workExperiences[i];
         if (!exp.companyName || !exp.period) {
-          setError(`${i+1}번째 직무경험의 모든 필드를 입력해주세요.`);
+          setError(`${i + 1}번째 직무경험의 모든 필드를 입력해주세요.`);
           return false;
         }
       }
@@ -355,7 +336,7 @@ const SpecInputPage = () => {
       for (let i = 0; i < formData.certifications.length; i++) {
         const cert = formData.certifications[i];
         if (!cert.name) {
-          setError(`${i+1}번째 자격증명을 입력해주세요.`);
+          setError(`${i + 1}번째 자격증명을 입력해주세요.`);
           return false;
         }
       }
@@ -366,7 +347,7 @@ const SpecInputPage = () => {
       for (let i = 0; i < formData.languageSkills.length; i++) {
         const lang = formData.languageSkills[i];
         if (!lang.score) {
-          setError(`${i+1}번째 어학능력의 점수를 입력해주세요.`);
+          setError(`${i + 1}번째 어학능력의 점수를 입력해주세요.`);
           return false;
         }
       }
@@ -377,7 +358,9 @@ const SpecInputPage = () => {
       for (let i = 0; i < formData.activities.length; i++) {
         const activity = formData.activities[i];
         if (!activity.name || !activity.role) {
-          setError(`${i+1}번째 활동/네트워킹의 활동명과 역할을 입력해주세요.`);
+          setError(
+            `${i + 1}번째 활동/네트워킹의 활동명과 역할을 입력해주세요.`
+          );
           return false;
         }
       }
@@ -392,33 +375,33 @@ const SpecInputPage = () => {
     const formattedData = {
       finalEducation: {
         institute: formData.finalEducation.institute,
-        status: formData.finalEducation.status  // finalStatus가 아닌 status로 사용
+        status: formData.finalEducation.status, // finalStatus가 아닌 status로 사용
       },
-      educationDetails: formData.educationDetails.map(edu => ({
+      educationDetails: formData.educationDetails.map((edu) => ({
         schoolName: edu.schoolName,
         degree: edu.degree,
         major: edu.major,
         gpa: parseFloat(edu.gpa),
-        maxGpa: parseFloat(edu.maxGpa)
+        maxGpa: parseFloat(edu.maxGpa),
       })),
-      workExperiences: formData.workExperiences.map(exp => ({
-        companyName: exp.companyName,  // company가 아닌 companyName으로 사용
+      workExperiences: formData.workExperiences.map((exp) => ({
+        companyName: exp.companyName, // company가 아닌 companyName으로 사용
         position: exp.position,
-        period: parseInt(exp.period) || 0
+        period: parseInt(exp.period) || 0,
       })),
-      certifications: formData.certifications.map(cert => ({
+      certifications: formData.certifications.map((cert) => ({
         name: cert.name,
       })),
-      languageSkills: formData.languageSkills.map(lang => ({
-        languageTest: lang.languageTest,  // name이 아닌 languageTest로 사용
-        score: lang.score
+      languageSkills: formData.languageSkills.map((lang) => ({
+        languageTest: lang.languageTest, // name이 아닌 languageTest로 사용
+        score: lang.score,
       })),
-      activities: formData.activities.map(activity => ({
+      activities: formData.activities.map((activity) => ({
         name: activity.name,
         role: activity.role,
-        award: activity.award || ''
+        award: activity.award || '',
       })),
-      jobField: formData.jobField
+      jobField: formData.jobField,
     };
 
     return formattedData;
@@ -428,69 +411,69 @@ const SpecInputPage = () => {
   const validateGpaInput = (value, maxGpa) => {
     // Remove any non-numeric characters except the decimal point
     let input = value.replace(/[^0-9.]/g, '');
-    
+
     // Ensure only one decimal point
     const parts = input.split('.');
     if (parts.length > 2) {
       input = parts[0] + '.' + parts.slice(1).join('');
     }
-    
+
     // Limit to 2 decimal places
     if (parts.length === 2 && parts[1].length > 2) {
       input = parts[0] + '.' + parts[1].slice(0, 2);
     }
-    
+
     // Ensure it doesn't exceed maxGpa
     const numValue = parseFloat(input);
     if (!isNaN(numValue) && numValue > parseFloat(maxGpa)) {
       input = maxGpa;
     }
-    
+
     // Ensure it's not negative
     if (!isNaN(numValue) && numValue < 0) {
       input = '0';
     }
-    
+
     return input;
   };
-  
+
   // Add a validation function for work period input
   const validatePeriodInput = (value) => {
     // Remove any non-numeric characters
     let input = value.replace(/[^0-9]/g, '');
-    
+
     // Limit to 3 digits
     if (input.length > 3) {
       input = input.slice(0, 3);
     }
-    
+
     // If input is '0', return empty string
     if (input === '0') {
       return '';
     }
-    
+
     return input;
   };
 
   // Create a specific handler for maxGpa changes
   const handleMaxGpaChange = (field, index, value) => {
     const newArray = [...formData[field]];
-    
+
     if (index >= 0 && index < newArray.length) {
       // Update maxGpa
       newArray[index] = {
         ...newArray[index],
-        maxGpa: value
+        maxGpa: value,
       };
-      
+
       // Also adjust gpa if it exceeds the new maxGpa
       if (parseFloat(newArray[index].gpa) > parseFloat(value)) {
         newArray[index].gpa = value;
       }
-      
-      setFormData(prev => ({
+
+      setFormData((prev) => ({
         ...prev,
-        [field]: newArray
+        [field]: newArray,
       }));
     }
   };
@@ -501,18 +484,20 @@ const SpecInputPage = () => {
     if (!validateForm()) {
       return;
     }
-    
+
     try {
       setLoading(true);
       setError(null); // 에러 상태 초기화
-      
+
       const submissionData = formatDataForSubmission();
       console.log('전송할 데이터:', submissionData);
-      
-      console.log(`API 요청: ${isEditMode ? 'PUT' : 'POST'} ${isEditMode ? `/api/specs/${activeSpecId}` : '/api/specs'}`);
-      
+
+      console.log(
+        `API 요청: ${isEditMode ? 'PUT' : 'POST'} ${isEditMode ? `/api/specs/${activeSpecId}` : '/api/specs'}`
+      );
+
       let response;
-      
+
       if (isEditMode) {
         // SpecAPI.updateSpec 함수 사용
         response = await SpecAPI.updateSpec(activeSpecId, submissionData);
@@ -520,17 +505,20 @@ const SpecInputPage = () => {
         // SpecAPI.createSpec 함수 사용
         response = await SpecAPI.createSpec(submissionData);
       }
-      
+
       console.log('API 응답:', response);
-      
+
       // HTTP 상태 코드로 성공 여부 확인
       if (response.status === 200 || response.status === 201) {
         console.log('스펙 정보 저장 성공');
         setSuccess(true);
+        showToast(
+          `스펙 정보가 성공적으로 ${isEditMode ? '수정' : '저장'}되었습니다.\n마이페이지로 이동합니다.`
+        );
         // 0.3초 후에 마이페이지로 이동
         setTimeout(() => {
           navigate('/my');
-        }, 300);
+        }, 1000);
       } else {
         console.error('예상치 못한 응답:', response);
         setError('스펙 정보 저장에 실패했습니다.');
@@ -538,13 +526,13 @@ const SpecInputPage = () => {
     } catch (err) {
       console.error('스펙 저장 중 오류 발생:', err);
       console.error('오류 응답:', err.response);
-      
+
       // 자세한 오류 메시지 표시
       if (err.response) {
         // 서버에서 응답이 온 경우
         console.error('응답 상태:', err.response.status);
         console.error('응답 데이터:', err.response.data);
-        
+
         if (err.response.data && err.response.data.message) {
           setError(`오류: ${err.response.data.message}`);
         } else {
@@ -566,82 +554,93 @@ const SpecInputPage = () => {
   const handleResumeFileChange = async (e) => {
     const file = e.target.files[0];
     if (!file) return;
-    
+
     // 파일 입력 초기화 (이후에 동일 파일 선택 가능하도록)
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
-    
+
     // PDF 파일인지 확인
     if (file.type !== 'application/pdf') {
       setFileErrorMessage('PDF 파일만 업로드 가능합니다.');
       setShowFileErrorModal(true);
       return;
     }
-    
+
     // 파일 크기 제한 (10MB)
     if (file.size > 10 * 1024 * 1024) {
-      setFileErrorMessage('파일 크기는 최대 10MB까지 가능합니다. 더 작은 파일을 선택해주세요.');
+      setFileErrorMessage(
+        '파일 크기는 최대 10MB까지 가능합니다. 더 작은 파일을 선택해주세요.'
+      );
       setShowFileErrorModal(true);
       return;
     }
-    
+
     try {
       setResumeLoading(true);
       setError(null);
-      
+
       // 이력서 분석 API 호출 (SpecAPI 사용)
       const response = await SpecAPI.analyzeResume(file);
-      
+
       console.log('이력서 분석 응답:', response.data);
-      
+
       if (response.data.isSuccess) {
         // 응답 데이터로 폼 채우기
         const resumeData = response.data.data;
-        
-        setFormData(prev => ({
+
+        setFormData((prev) => ({
           ...prev,
           finalEducation: {
             institute: resumeData.finalEducation?.institute || '대학교',
-            status: resumeData.finalEducation?.finalStatus || '졸업'
+            status: resumeData.finalEducation?.finalStatus || '졸업',
           },
-          educationDetails: resumeData.educationDetails?.map(edu => ({
-            schoolName: edu.schoolName || '',
-            degree: edu.degree || '학사',
-            major: edu.major || '',
-            gpa: edu.gpa?.toString() || '',
-            maxGpa: edu.maxGpa?.toString() || '4.5'
-          })) || [],
-          workExperiences: resumeData.workExperiences?.map(exp => ({
-            companyName: exp.company || '',
-            position: exp.position || '인턴',
-            period: exp.period?.toString() || ''
-          })) || [],
-          certifications: resumeData.certifications?.map(cert => ({
-            name: cert.name || ''
-          })) || [],
-          languageSkills: resumeData.languageSkills?.map(lang => ({
-            languageTest: lang.name || '',
-            score: lang.score || ''
-          })) || [],
-          activities: resumeData.activities?.map(activity => ({
-            name: activity.name || '',
-            role: activity.role || '',
-            award: activity.award || ''
-          })) || [],
-          jobField: resumeData.jobField || '인터넷_IT'
+          educationDetails:
+            resumeData.educationDetails?.map((edu) => ({
+              schoolName: edu.schoolName || '',
+              degree: edu.degree || '학사',
+              major: edu.major || '',
+              gpa: edu.gpa?.toString() || '',
+              maxGpa: edu.maxGpa?.toString() || '4.5',
+            })) || [],
+          workExperiences:
+            resumeData.workExperiences?.map((exp) => ({
+              companyName: exp.company || '',
+              position: exp.position || '인턴',
+              period: exp.period?.toString() || '',
+            })) || [],
+          certifications:
+            resumeData.certifications?.map((cert) => ({
+              name: cert.name || '',
+            })) || [],
+          languageSkills:
+            resumeData.languageSkills?.map((lang) => ({
+              languageTest: lang.name || '',
+              score: lang.score || '',
+            })) || [],
+          activities:
+            resumeData.activities?.map((activity) => ({
+              name: activity.name || '',
+              role: activity.role || '',
+              award: activity.award || '',
+            })) || [],
+          jobField: resumeData.jobField || '인터넷_IT',
         }));
-        
+
         // 성공 메시지
         alert('이력서 분석이 완료되었습니다.');
       } else {
         // API 응답이 실패인 경우
-        setFileErrorMessage('이력서 분석에 실패했습니다. 다른 파일을 시도해보세요.');
+        setFileErrorMessage(
+          '이력서 분석에 실패했습니다. 다른 파일을 시도해보세요.'
+        );
         setShowFileErrorModal(true);
       }
     } catch (err) {
       console.error('이력서 분석 중 오류 발생:', err);
-      setFileErrorMessage('이력서 분석 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      setFileErrorMessage(
+        '이력서 분석 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'
+      );
       setShowFileErrorModal(true);
     } finally {
       setResumeLoading(false);
@@ -658,12 +657,22 @@ const SpecInputPage = () => {
 
   // 추가/삭제 버튼 컴포넌트
   const AddButton = ({ onClick }) => (
-    <button 
+    <button
       type="button"
-      className="flex items-center justify-center w-6 h-6 text-white bg-red-500 rounded-lg" 
+      className="flex items-center justify-center w-6 h-6 text-white bg-red-500 rounded-lg"
       onClick={onClick}
     >
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
         <line x1="12" y1="5" x2="12" y2="19"></line>
         <line x1="5" y1="12" x2="19" y2="12"></line>
       </svg>
@@ -671,12 +680,22 @@ const SpecInputPage = () => {
   );
 
   const RemoveButton = ({ onClick }) => (
-    <button 
+    <button
       type="button"
-      className="flex items-center justify-center w-6 h-6 text-white bg-red-500 rounded-lg" 
+      className="flex items-center justify-center w-6 h-6 text-white bg-red-500 rounded-lg"
       onClick={onClick}
     >
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
         <line x1="5" y1="12" x2="19" y2="12"></line>
       </svg>
     </button>
@@ -685,19 +704,22 @@ const SpecInputPage = () => {
   return (
     <div className="flex flex-col w-full min-h-screen bg-gray-50 pb-16">
       <div className="relative flex flex-col flex-1 w-full max-w-md mx-auto bg-white overflow-visible">
-        
         {/* 성공 메시지 */}
-        {success && (
+        {/* {success && (
           <div className="fixed left-0 right-0 z-50 max-w-md px-4 py-2 mx-auto text-white bg-green-500 rounded shadow-lg top-16">
             스펙 정보가 성공적으로 {isEditMode ? '수정' : '저장'}되었습니다. 마이페이지로 이동합니다.
           </div>
-        )}
-        
+        )} */}
+
         <div className="p-4">
           <h2 className="mb-4 text-lg font-medium text-center text-blue-600">
-            {initialDataLoaded ? (isEditMode ? '스펙 정보를 수정해주세요!' : '당신의 스펙을 입력해주세요!') : '데이터를 불러오는 중...'}
+            {initialDataLoaded
+              ? isEditMode
+                ? '스펙 정보를 수정해주세요!'
+                : '당신의 스펙을 입력해주세요!'
+              : '데이터를 불러오는 중...'}
           </h2>
-          
+
           {/* 이력서로 빠르게 입력하기 버튼 */}
           <div className="mb-6">
             <input
@@ -715,16 +737,43 @@ const SpecInputPage = () => {
             >
               {resumeLoading ? (
                 <>
-                  <svg className="w-5 h-5 mr-3 -ml-1 text-white animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                  <svg
+                    className="w-5 h-5 mr-3 -ml-1 text-white animate-spin"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    ></circle>
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    ></path>
                   </svg>
                   이력서 분석중...
                 </>
               ) : (
                 <>
-                  <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="w-5 h-5 mr-2"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                    />
                   </svg>
                   이력서로 빠르게 입력하기!
                 </>
@@ -734,12 +783,13 @@ const SpecInputPage = () => {
               PDF 파일만 업로드 가능합니다. (최대 10MB)
             </p>
           </div>
-          
+
           <div className="space-y-4">
             {/* 기본 정보 섹션 */}
             <div className="mb-2">
               <label className="block text-lg font-medium">
-                닉네임 <span className="text-red-500">*</span><span className="ml-1 text-xs text-gray-500">(필수)</span>
+                닉네임 <span className="text-red-500">*</span>
+                <span className="ml-1 text-xs text-gray-500">(필수)</span>
               </label>
             </div>
             <div className="p-4 bg-gray-100 rounded-lg">
@@ -754,7 +804,8 @@ const SpecInputPage = () => {
             {/* 최종 학력 섹션 */}
             <div className="mb-2">
               <h3 className="text-lg font-medium">
-                최종 학력 <span className="text-red-500">*</span><span className="ml-1 text-xs text-gray-500">(필수)</span>
+                최종 학력 <span className="text-red-500">*</span>
+                <span className="ml-1 text-xs text-gray-500">(필수)</span>
               </h3>
             </div>
             <div className="p-4 bg-gray-100 rounded-lg">
@@ -762,286 +813,503 @@ const SpecInputPage = () => {
                 <select
                   className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
                   value={formData.finalEducation.institute}
-                  onChange={(e) => handleNestedInputChange('finalEducation', 'institute', e.target.value)}
+                  onChange={(e) =>
+                    handleNestedInputChange(
+                      'finalEducation',
+                      'institute',
+                      e.target.value
+                    )
+                  }
                 >
                   {INSTITUTES.map((institute, index) => (
-                    <option key={index} value={institute}>{institute}</option>
+                    <option key={index} value={institute}>
+                      {institute}
+                    </option>
                   ))}
                 </select>
                 <select
                   className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
                   value={formData.finalEducation.status}
-                  onChange={(e) => handleNestedInputChange('finalEducation', 'status', e.target.value)}
+                  onChange={(e) =>
+                    handleNestedInputChange(
+                      'finalEducation',
+                      'status',
+                      e.target.value
+                    )
+                  }
                 >
                   {EDUCATION_STATUS.map((status, index) => (
-                    <option key={index} value={status}>{status}</option>
+                    <option key={index} value={status}>
+                      {status}
+                    </option>
                   ))}
                 </select>
               </div>
             </div>
-            
+
             {/* 학력 정보 섹션 */}
             <div className="flex items-center justify-between">
               <div className="flex items-center">
                 <h3 className="text-lg font-medium">학력</h3>
-                <span className="ml-2 text-xs text-gray-500">(국내 대학 한정입니다)</span>
+                <span className="ml-2 text-xs text-gray-500">
+                  (국내 대학 한정입니다)
+                </span>
               </div>
-              <AddButton onClick={() => addArrayItem('educationDetails', { schoolName: '', major: '', degree: '학사', gpa: '', maxGpa: '4.5' })} />
+              <AddButton
+                onClick={() =>
+                  addArrayItem('educationDetails', {
+                    schoolName: '',
+                    major: '',
+                    degree: '학사',
+                    gpa: '',
+                    maxGpa: '4.5',
+                  })
+                }
+              />
             </div>
-            {Array.isArray(formData.educationDetails) && formData.educationDetails.length > 0 ? (
-              formData.educationDetails.map((education, index) => (
-                <div key={`academic-${index}`} className="relative p-4 mb-4 bg-gray-100 rounded-lg">
-                  <div className="space-y-3">
-                    <div className="grid grid-cols-2 gap-4">
-                      <div>
-                        <label className="block mb-1 text-sm font-medium text-gray-600">학교명</label>
-                        <p className="mb-1 text-xs text-gray-500">전체 이름을 입력하세요</p>
-                        <input
-                          type="text"
-                          maxLength="30"
-                          className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
-                          value={education.schoolName}
-                          onChange={(e) => handleArrayInputChange('educationDetails', index, 'schoolName', e.target.value)}
-                        />
+            {Array.isArray(formData.educationDetails) &&
+            formData.educationDetails.length > 0
+              ? formData.educationDetails.map((education, index) => (
+                  <div
+                    key={`academic-${index}`}
+                    className="relative p-4 mb-4 bg-gray-100 rounded-lg"
+                  >
+                    <div className="space-y-3">
+                      <div className="grid grid-cols-2 gap-4">
+                        <div>
+                          <label className="block mb-1 text-sm font-medium text-gray-600">
+                            학교명
+                          </label>
+                          <p className="mb-1 text-xs text-gray-500">
+                            전체 이름을 입력하세요
+                          </p>
+                          <input
+                            type="text"
+                            maxLength="30"
+                            className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+                            value={education.schoolName}
+                            onChange={(e) =>
+                              handleArrayInputChange(
+                                'educationDetails',
+                                index,
+                                'schoolName',
+                                e.target.value
+                              )
+                            }
+                          />
+                        </div>
+                        <div>
+                          <label className="block mb-1 text-sm font-medium text-gray-600">
+                            학위
+                          </label>
+                          <select
+                            className="block w-full px-3 py-2 mt-6 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+                            value={education.degree}
+                            onChange={(e) =>
+                              handleArrayInputChange(
+                                'educationDetails',
+                                index,
+                                'degree',
+                                e.target.value
+                              )
+                            }
+                          >
+                            {DEGREE_TYPES.map((degree, idx) => (
+                              <option key={idx} value={degree}>
+                                {degree}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
                       </div>
-                      <div>
-                        <label className="block mb-1 text-sm font-medium text-gray-600">학위</label>
-                        <select
-                          className="block w-full px-3 py-2 mt-6 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
-                          value={education.degree}
-                          onChange={(e) => handleArrayInputChange('educationDetails', index, 'degree', e.target.value)}
-                        >
-                          {DEGREE_TYPES.map((degree, idx) => (
-                            <option key={idx} value={degree}>{degree}</option>
-                          ))}
-                        </select>
+                      <div className="grid grid-cols-2 gap-4">
+                        <div>
+                          <label className="block mb-1 text-sm font-medium text-gray-600">
+                            전공
+                          </label>
+                          <input
+                            type="text"
+                            maxLength="20"
+                            className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+                            value={education.major}
+                            onChange={(e) =>
+                              handleArrayInputChange(
+                                'educationDetails',
+                                index,
+                                'major',
+                                e.target.value
+                              )
+                            }
+                          />
+                        </div>
+                        <div>{/* 빈 공간 */}</div>
+                      </div>
+                      <div className="grid grid-cols-2 gap-4">
+                        <div>
+                          <label className="block mb-1 text-sm font-medium text-gray-600">
+                            학점
+                          </label>
+                          <input
+                            type="text"
+                            inputMode="decimal"
+                            className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+                            value={education.gpa}
+                            onChange={(e) => {
+                              const validatedValue = validateGpaInput(
+                                e.target.value,
+                                education.maxGpa
+                              );
+                              handleArrayInputChange(
+                                'educationDetails',
+                                index,
+                                'gpa',
+                                validatedValue
+                              );
+                            }}
+                            placeholder="예: 3.75"
+                          />
+                        </div>
+                        <div>
+                          <label className="block mb-1 text-sm font-medium text-gray-600">
+                            최대 학점
+                          </label>
+                          <select
+                            className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+                            value={education.maxGpa}
+                            onChange={(e) =>
+                              handleMaxGpaChange(
+                                'educationDetails',
+                                index,
+                                e.target.value
+                              )
+                            }
+                          >
+                            {GPA_SCALE.map((scale, idx) => (
+                              <option key={idx} value={scale}>
+                                {scale}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
                       </div>
                     </div>
-                    <div className="grid grid-cols-2 gap-4">
-                      <div>
-                        <label className="block mb-1 text-sm font-medium text-gray-600">전공</label>
-                        <input
-                          type="text"
-                          maxLength="20"
-                          className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
-                          value={education.major}
-                          onChange={(e) => handleArrayInputChange('educationDetails', index, 'major', e.target.value)}
-                        />
-                      </div>
-                      <div>
-                        {/* 빈 공간 */}
-                      </div>
-                    </div>
-                    <div className="grid grid-cols-2 gap-4">
-                      <div>
-                        <label className="block mb-1 text-sm font-medium text-gray-600">학점</label>
-                        <input
-                          type="text"
-                          inputMode="decimal"
-                          className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
-                          value={education.gpa}
-                          onChange={(e) => {
-                            const validatedValue = validateGpaInput(e.target.value, education.maxGpa);
-                            handleArrayInputChange('educationDetails', index, 'gpa', validatedValue);
-                          }}
-                          placeholder="예: 3.75"
-                        />
-                      </div>
-                      <div>
-                        <label className="block mb-1 text-sm font-medium text-gray-600">최대 학점</label>
-                        <select
-                          className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
-                          value={education.maxGpa}
-                          onChange={(e) => handleMaxGpaChange('educationDetails', index, e.target.value)}
-                        >
-                          {GPA_SCALE.map((scale, idx) => (
-                            <option key={idx} value={scale}>{scale}</option>
-                          ))}
-                        </select>
-                      </div>
+                    <div className="absolute right-2 top-2">
+                      <RemoveButton
+                        onClick={() =>
+                          removeArrayItem('educationDetails', index)
+                        }
+                      />
                     </div>
                   </div>
-                  <div className="absolute right-2 top-2">
-                    <RemoveButton onClick={() => removeArrayItem('educationDetails', index)} />
-                  </div>
-                </div>
-              ))
-            ) : null}
+                ))
+              : null}
 
             {/* 직무경험 섹션 */}
             <div className="flex items-center justify-between">
               <h3 className="text-lg font-medium">직무경험</h3>
-              <AddButton onClick={() => addArrayItem('workExperiences', { companyName: '', position: '인턴', period: '' })} />
+              <AddButton
+                onClick={() =>
+                  addArrayItem('workExperiences', {
+                    companyName: '',
+                    position: '인턴',
+                    period: '',
+                  })
+                }
+              />
             </div>
-            {Array.isArray(formData.workExperiences) && formData.workExperiences.length > 0 ? (
-              formData.workExperiences.map((experience, index) => (
-                <div key={`career-${index}`} className="relative p-4 mb-4 bg-gray-100 rounded-lg">
-                  <div className="space-y-3">
-                    <div className="grid grid-cols-2 gap-4">
-                      <div>
-                        <label className="block mb-1 text-sm font-medium text-gray-600">회사명</label>
-                        <input
-                          type="text"
-                          maxLength="20"
-                          className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
-                          placeholder="예: 삼성 SDS"
-                          value={experience.companyName}
-                          onChange={(e) => handleArrayInputChange('workExperiences', index, 'companyName', e.target.value)}
-                        />
+            {Array.isArray(formData.workExperiences) &&
+            formData.workExperiences.length > 0
+              ? formData.workExperiences.map((experience, index) => (
+                  <div
+                    key={`career-${index}`}
+                    className="relative p-4 mb-4 bg-gray-100 rounded-lg"
+                  >
+                    <div className="space-y-3">
+                      <div className="grid grid-cols-2 gap-4">
+                        <div>
+                          <label className="block mb-1 text-sm font-medium text-gray-600">
+                            회사명
+                          </label>
+                          <input
+                            type="text"
+                            maxLength="20"
+                            className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+                            placeholder="예: 삼성 SDS"
+                            value={experience.companyName}
+                            onChange={(e) =>
+                              handleArrayInputChange(
+                                'workExperiences',
+                                index,
+                                'companyName',
+                                e.target.value
+                              )
+                            }
+                          />
+                        </div>
+                        <div>
+                          <label className="block mb-1 text-sm font-medium text-gray-600">
+                            직책
+                          </label>
+                          <select
+                            className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+                            value={experience.position}
+                            onChange={(e) =>
+                              handleArrayInputChange(
+                                'workExperiences',
+                                index,
+                                'position',
+                                e.target.value
+                              )
+                            }
+                          >
+                            {POSITIONS.map((position, idx) => (
+                              <option key={idx} value={position}>
+                                {position}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
                       </div>
                       <div>
-                        <label className="block mb-1 text-sm font-medium text-gray-600">직책</label>
-                        <select
-                          className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
-                          value={experience.position}
-                          onChange={(e) => handleArrayInputChange('workExperiences', index, 'position', e.target.value)}
-                        >
-                          {POSITIONS.map((position, idx) => (
-                            <option key={idx} value={position}>{position}</option>
-                          ))}
-                        </select>
+                        <label className="block mb-1 text-sm font-medium text-gray-600">
+                          근무기간 (개월)
+                        </label>
+                        <div className="flex items-center gap-2">
+                          <input
+                            type="text"
+                            inputMode="numeric"
+                            className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+                            value={experience.period}
+                            onChange={(e) => {
+                              const validatedValue = validatePeriodInput(
+                                e.target.value
+                              );
+                              handleArrayInputChange(
+                                'workExperiences',
+                                index,
+                                'period',
+                                validatedValue
+                              );
+                            }}
+                            placeholder="예: 12"
+                          />
+                          <span className="text-xs text-gray-500">
+                            *최대 3자리까지만 입력 가능
+                          </span>
+                        </div>
                       </div>
                     </div>
-                    <div>
-                      <label className="block mb-1 text-sm font-medium text-gray-600">근무기간 (개월)</label>
-                      <div className="flex items-center gap-2">
-                        <input
-                          type="text"
-                          inputMode="numeric"
-                          className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
-                          value={experience.period}
-                          onChange={(e) => {
-                            const validatedValue = validatePeriodInput(e.target.value);
-                            handleArrayInputChange('workExperiences', index, 'period', validatedValue);
-                          }}
-                          placeholder="예: 12"
-                        />
-                        <span className="text-xs text-gray-500">*최대 3자리까지만 입력 가능</span>
-                      </div>
+                    <div className="absolute right-2 top-2">
+                      <RemoveButton
+                        onClick={() =>
+                          removeArrayItem('workExperiences', index)
+                        }
+                      />
                     </div>
                   </div>
-                  <div className="absolute right-2 top-2">
-                    <RemoveButton onClick={() => removeArrayItem('workExperiences', index)} />
-                  </div>
-                </div>
-              ))
-            ) : null}
+                ))
+              : null}
 
             {/* 자격증 섹션 */}
             <div className="flex items-center justify-between">
               <h3 className="text-lg font-medium">자격증</h3>
-              <AddButton onClick={() => addArrayItem('certifications', { name: '' })} />
+              <AddButton
+                onClick={() => addArrayItem('certifications', { name: '' })}
+              />
             </div>
-            {Array.isArray(formData.certifications) && formData.certifications.length > 0 ? (
-              formData.certifications.map((cert, index) => (
-                <div key={`cert-${index}`} className="relative p-4 mb-4 bg-gray-100 rounded-lg">
-                  <div>
-                    <label className="block mb-1 text-sm font-medium text-gray-600">자격증명</label>
-                    <input
-                      type="text"
-                      maxLength="50"
-                      className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
-                      value={cert.name}
-                      onChange={(e) => handleArrayInputChange('certifications', index, 'name', e.target.value)}
-                    />
+            {Array.isArray(formData.certifications) &&
+            formData.certifications.length > 0
+              ? formData.certifications.map((cert, index) => (
+                  <div
+                    key={`cert-${index}`}
+                    className="relative p-4 mb-4 bg-gray-100 rounded-lg"
+                  >
+                    <div>
+                      <label className="block mb-1 text-sm font-medium text-gray-600">
+                        자격증명
+                      </label>
+                      <input
+                        type="text"
+                        maxLength="50"
+                        className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        value={cert.name}
+                        onChange={(e) =>
+                          handleArrayInputChange(
+                            'certifications',
+                            index,
+                            'name',
+                            e.target.value
+                          )
+                        }
+                      />
+                    </div>
+                    <div className="absolute right-2 top-2">
+                      <RemoveButton
+                        onClick={() => removeArrayItem('certifications', index)}
+                      />
+                    </div>
                   </div>
-                  <div className="absolute right-2 top-2">
-                    <RemoveButton onClick={() => removeArrayItem('certifications', index)} />
-                  </div>
-                </div>
-              ))
-            ) : null}
+                ))
+              : null}
 
             {/* 어학능력 섹션 */}
             <div className="flex items-center justify-between">
               <h3 className="text-lg font-medium">어학능력</h3>
-              <AddButton onClick={() => addArrayItem('languageSkills', { languageTest: 'TOEIC_ENGLISH', score: '' })} />
+              <AddButton
+                onClick={() =>
+                  addArrayItem('languageSkills', {
+                    languageTest: 'TOEIC_ENGLISH',
+                    score: '',
+                  })
+                }
+              />
             </div>
-            {Array.isArray(formData.languageSkills) && formData.languageSkills.length > 0 ? (
-              formData.languageSkills.map((lang, index) => (
-                <div key={`lang-${index}`} className="relative p-4 mb-4 bg-gray-100 rounded-lg">
-                  <div className="grid grid-cols-2 gap-4">
-                    <select
-                      className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
-                      value={lang.languageTest}
-                      onChange={(e) => handleArrayInputChange('languageSkills', index, 'languageTest', e.target.value)}
-                    >
-                      {LANGUAGE_TESTS.map((test, idx) => (
-                        <option key={idx} value={test.value}>{test.label}</option>
-                      ))}
-                    </select>
-                    <input
-                      type="text"
-                      maxLength="10"
-                      className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
-                      placeholder="점수/등급"
-                      value={lang.score}
-                      onChange={(e) => handleArrayInputChange('languageSkills', index, 'score', e.target.value)}
-                    />
+            {Array.isArray(formData.languageSkills) &&
+            formData.languageSkills.length > 0
+              ? formData.languageSkills.map((lang, index) => (
+                  <div
+                    key={`lang-${index}`}
+                    className="relative p-4 mb-4 bg-gray-100 rounded-lg"
+                  >
+                    <div className="grid grid-cols-2 gap-4">
+                      <select
+                        className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        value={lang.languageTest}
+                        onChange={(e) =>
+                          handleArrayInputChange(
+                            'languageSkills',
+                            index,
+                            'languageTest',
+                            e.target.value
+                          )
+                        }
+                      >
+                        {LANGUAGE_TESTS.map((test, idx) => (
+                          <option key={idx} value={test.value}>
+                            {test.label}
+                          </option>
+                        ))}
+                      </select>
+                      <input
+                        type="text"
+                        maxLength="10"
+                        className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        placeholder="점수/등급"
+                        value={lang.score}
+                        onChange={(e) =>
+                          handleArrayInputChange(
+                            'languageSkills',
+                            index,
+                            'score',
+                            e.target.value
+                          )
+                        }
+                      />
+                    </div>
+                    <div className="absolute right-2 top-2">
+                      <RemoveButton
+                        onClick={() => removeArrayItem('languageSkills', index)}
+                      />
+                    </div>
                   </div>
-                  <div className="absolute right-2 top-2">
-                    <RemoveButton onClick={() => removeArrayItem('languageSkills', index)} />
-                  </div>
-                </div>
-              ))
-            ) : null}
+                ))
+              : null}
 
             {/* 활동/네트워킹 섹션 */}
             <div className="flex items-center justify-between">
               <h3 className="text-lg font-medium">활동/네트워킹</h3>
-              <AddButton onClick={() => addArrayItem('activities', { name: '', role: '', award: '' })} />
+              <AddButton
+                onClick={() =>
+                  addArrayItem('activities', { name: '', role: '', award: '' })
+                }
+              />
             </div>
-            {Array.isArray(formData.activities) && formData.activities.length > 0 ? (
-              formData.activities.map((activity, index) => (
-                <div key={`activity-${index}`} className="relative p-4 mb-4 bg-gray-100 rounded-lg">
-                  <div className="space-y-3">
-                    <div className="grid grid-cols-2 gap-4">
-                      <div>
-                        <label className="block mb-1 text-sm font-medium text-gray-600">활동명</label>
-                        <input
-                          type="text"
-                          maxLength="20"
-                          className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
-                          placeholder="예: 대학생 마케팅 동아리"
-                          value={activity.name}
-                          onChange={(e) => handleArrayInputChange('activities', index, 'name', e.target.value)}
-                        />
+            {Array.isArray(formData.activities) &&
+            formData.activities.length > 0
+              ? formData.activities.map((activity, index) => (
+                  <div
+                    key={`activity-${index}`}
+                    className="relative p-4 mb-4 bg-gray-100 rounded-lg"
+                  >
+                    <div className="space-y-3">
+                      <div className="grid grid-cols-2 gap-4">
+                        <div>
+                          <label className="block mb-1 text-sm font-medium text-gray-600">
+                            활동명
+                          </label>
+                          <input
+                            type="text"
+                            maxLength="20"
+                            className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+                            placeholder="예: 대학생 마케팅 동아리"
+                            value={activity.name}
+                            onChange={(e) =>
+                              handleArrayInputChange(
+                                'activities',
+                                index,
+                                'name',
+                                e.target.value
+                              )
+                            }
+                          />
+                        </div>
+                        <div>
+                          <label className="block mb-1 text-sm font-medium text-gray-600">
+                            역할
+                          </label>
+                          <input
+                            type="text"
+                            maxLength="15"
+                            className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+                            placeholder="예: 팀장, 팀원 등"
+                            value={activity.role}
+                            onChange={(e) =>
+                              handleArrayInputChange(
+                                'activities',
+                                index,
+                                'role',
+                                e.target.value
+                              )
+                            }
+                          />
+                        </div>
                       </div>
                       <div>
-                        <label className="block mb-1 text-sm font-medium text-gray-600">역할</label>
-                        <input
-                          type="text"
-                          maxLength="15"
+                        <label className="block mb-1 text-sm font-medium text-gray-600">
+                          수상내역{' '}
+                          <span className="text-xs text-gray-500">(선택)</span>
+                        </label>
+                        <textarea
                           className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
-                          placeholder="예: 팀장, 팀원 등"
-                          value={activity.role}
-                          onChange={(e) => handleArrayInputChange('activities', index, 'role', e.target.value)}
+                          placeholder="수상 내역이 있으시면 입력하세요"
+                          maxLength="20"
+                          value={activity.award || ''}
+                          onChange={(e) =>
+                            handleArrayInputChange(
+                              'activities',
+                              index,
+                              'award',
+                              e.target.value
+                            )
+                          }
+                          rows={2}
                         />
                       </div>
                     </div>
-                    <div>
-                      <label className="block mb-1 text-sm font-medium text-gray-600">수상내역 <span className="text-xs text-gray-500">(선택)</span></label>
-                      <textarea
-                        className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
-                        placeholder="수상 내역이 있으시면 입력하세요"
-                        maxLength="20"
-                        value={activity.award || ''}
-                        onChange={(e) => handleArrayInputChange('activities', index, 'award', e.target.value)}
-                        rows={2}
+                    <div className="absolute right-2 top-2">
+                      <RemoveButton
+                        onClick={() => removeArrayItem('activities', index)}
                       />
                     </div>
                   </div>
-                  <div className="absolute right-2 top-2">
-                    <RemoveButton onClick={() => removeArrayItem('activities', index)} />
-                  </div>
-                </div>
-              ))
-            ) : null}
+                ))
+              : null}
 
             {/* 지원 분야 */}
             <div className="mb-2">
               <h3 className="text-lg font-medium">
-                지원 분야 <span className="text-red-500">*</span><span className="ml-1 text-xs text-gray-500">(필수)</span>
+                지원 분야 <span className="text-red-500">*</span>
+                <span className="ml-1 text-xs text-gray-500">(필수)</span>
               </h3>
             </div>
             <div className="p-4 bg-gray-100 rounded-lg">
@@ -1051,7 +1319,9 @@ const SpecInputPage = () => {
                 onChange={(e) => handleInputChange('jobField', e.target.value)}
               >
                 {JOB_FIELDS.map((field, index) => (
-                  <option key={index} value={field}>{field}</option>
+                  <option key={index} value={field}>
+                    {field}
+                  </option>
                 ))}
               </select>
             </div>
@@ -1062,17 +1332,49 @@ const SpecInputPage = () => {
                 <div className="relative flex items-center justify-between px-4 py-3 mb-3 text-gray-900 bg-red-300 border border-red-400 rounded-md">
                   <div className="flex items-center">
                     <div className="flex-shrink-0 mr-3 text-red-600">
-                      <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <circle cx="12" cy="12" r="11" stroke="currentColor" strokeWidth="2" />
-                        <path d="M12 8L12 13" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+                      <svg
+                        className="w-6 h-6"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="12"
+                          cy="12"
+                          r="11"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                        />
+                        <path
+                          d="M12 8L12 13"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                        />
                         <circle cx="12" cy="16" r="1" fill="currentColor" />
                       </svg>
                     </div>
                     <span className="text-sm font-medium">{error}</span>
                   </div>
-                  <button type="button" className="text-gray-500 hover:text-gray-700" onClick={clearError}>
-                    <svg className="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+                  <button
+                    type="button"
+                    className="text-gray-500 hover:text-gray-700"
+                    onClick={clearError}
+                  >
+                    <svg
+                      className="w-5 h-5"
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        d="M6 18L18 6M6 6l12 12"
+                      />
                     </svg>
                   </button>
                 </div>
@@ -1088,18 +1390,45 @@ const SpecInputPage = () => {
                 disabled={loading}
               >
                 {loading ? (
-                  <svg className="w-5 h-5 mr-3 -ml-1 text-white animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                  <svg
+                    className="w-5 h-5 mr-3 -ml-1 text-white animate-spin"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    ></circle>
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    ></path>
                   </svg>
                 ) : (
-                  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mr-2">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="mr-2"
+                  >
                     <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"></path>
                     <polyline points="17 21 17 13 7 13 7 21"></polyline>
                     <polyline points="7 3 7 8 15 8"></polyline>
                   </svg>
                 )}
-                {loading ? "처리 중..." : (isEditMode ? "수정" : "저장")}
+                {loading ? '처리 중...' : isEditMode ? '수정' : '저장'}
               </button>
               <button
                 type="button"
@@ -1107,7 +1436,18 @@ const SpecInputPage = () => {
                 onClick={handleCancelAttempt}
                 disabled={loading}
               >
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mr-2">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="mr-2"
+                >
                   <line x1="18" y1="6" x2="6" y2="18"></line>
                   <line x1="6" y1="6" x2="18" y2="18"></line>
                 </svg>
@@ -1116,25 +1456,54 @@ const SpecInputPage = () => {
             </div>
           </div>
         </div>
-        
+
         {showConfirmModal && (
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-30">
             <div className="w-11/12 max-w-sm p-6 bg-white rounded-lg shadow-lg">
               <div className="flex justify-end">
-                <button onClick={handleCloseModal} className="text-gray-500 hover:text-gray-700">
-                  <svg xmlns="http://www.w3.org/2000/svg" className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                <button
+                  onClick={handleCloseModal}
+                  className="text-gray-500 hover:text-gray-700"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="w-6 h-6"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
                   </svg>
                 </button>
               </div>
               <div className="flex flex-col items-center">
                 <div className="p-4 mb-4 bg-red-100 rounded-full">
-                  <svg xmlns="http://www.w3.org/2000/svg" className="w-8 h-8 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M12 2a10 10 0 11-0 20 10 10 0 010-20z" />
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="w-8 h-8 text-red-500"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 8v4m0 4h.01M12 2a10 10 0 11-0 20 10 10 0 010-20z"
+                    />
                   </svg>
                 </div>
-                <p className="mb-6 text-lg font-semibold text-gray-800">스펙 입력을 그만하시겠습니까?</p>
-                <p className="mb-6 text-sm text-gray-500">입력 중인 내용은 저장되지 않습니다.</p>
+                <p className="mb-6 text-lg font-semibold text-gray-800">
+                  스펙 입력을 그만하시겠습니까?
+                </p>
+                <p className="mb-6 text-sm text-gray-500">
+                  입력 중인 내용은 저장되지 않습니다.
+                </p>
                 <div className="flex w-full space-x-4">
                   <button
                     onClick={handleConfirmCancel}
@@ -1153,26 +1522,55 @@ const SpecInputPage = () => {
             </div>
           </div>
         )}
-        
+
         {/* 파일 에러 모달 */}
         {showFileErrorModal && (
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-30">
             <div className="w-11/12 max-w-sm p-6 bg-white rounded-lg shadow-lg">
               <div className="flex justify-end">
-                <button onClick={() => setShowFileErrorModal(false)} className="text-gray-500 hover:text-gray-700">
-                  <svg xmlns="http://www.w3.org/2000/svg" className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                <button
+                  onClick={() => setShowFileErrorModal(false)}
+                  className="text-gray-500 hover:text-gray-700"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="w-6 h-6"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
                   </svg>
                 </button>
               </div>
               <div className="flex flex-col items-center">
                 <div className="p-4 mb-4 bg-red-100 rounded-full">
-                  <svg xmlns="http://www.w3.org/2000/svg" className="w-8 h-8 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M12 2a10 10 0 11-0 20 10 10 0 010-20z" />
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="w-8 h-8 text-red-500"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 8v4m0 4h.01M12 2a10 10 0 11-0 20 10 10 0 010-20z"
+                    />
                   </svg>
                 </div>
-                <p className="mb-3 text-lg font-semibold text-gray-800">이력서 파일 오류</p>
-                <p className="mb-6 text-sm text-center text-gray-600">{fileErrorMessage}</p>
+                <p className="mb-3 text-lg font-semibold text-gray-800">
+                  이력서 파일 오류
+                </p>
+                <p className="mb-6 text-sm text-center text-gray-600">
+                  {fileErrorMessage}
+                </p>
                 <div className="flex w-full">
                   <button
                     onClick={() => setShowFileErrorModal(false)}
@@ -1186,6 +1584,8 @@ const SpecInputPage = () => {
           </div>
         )}
       </div>
+
+      <ToastContainer toasts={toasts} removeToast={removeToast} />
     </div>
   );
 };


### PR DESCRIPTION
## ☝️ 요약
렌더링 문제 해결, 로그인 두 번 시도해야 성공하는 문제 해결 시도, 디자인 수정

<br/>

## ✏️ 상세 내용
- 홈페이지, 소셜페이지 렌더링 시 깜빡이며 불필요한 요소들이 나타나는 문제
  - return문을 조건에 따라 여러 개 작성하면 조건을 충족하는 잠깐의 시간 동안 해당 요소가 화면에 나타나는 것임
  - 조건문 수정하여 문제 해결

- 서비스 화면 테두리에 그림자가 안 나타나는 문제
  - 개발 환경에서는 모든 페이지에 그림자가 나타나는데 운영 환경에서는 홈페이지에서만 그림자가 나타남
  - App.jsx의 태그 안에 그림자를 설정했는데 App.css에 선언하여 사용하는 방식으로 수정함
- 기타 디자인 수정
  - /chat 접속 시 하단메뉴바 DM 메뉴 활성화
  - SpecInputPage 토스트 메시지 ui 통일
  - ServiceIntro 텍스트 수정
  - 랭킹페이지, 랭킹결과페이지의 RankingItem 간 간격 축소
- 간헐적으로 로그인을 두 번 시도해야 성공하는 문제
  - OAuthRedirectPage에서 login 함수와 deleteCookie 함수가 비동기적으로 처리되어 홈페이지로 이동하는 타이밍이 어긋나는 것으로 예상됨
  - useState 활용해 login 함수와 deleteCookie 함수가 끝나야 홈페이지로 넘어가도록 처리함

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.
- [x] 로컬 테스트 완료했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)
#44 

<br/>

## 비고 (선택)