### PR TITLE
fix: 채팅페이지 이동 시 세션스토리지에 정보 안 담기는 문제 수정

### DIFF
--- a/src/pages/SocialPage.jsx
+++ b/src/pages/SocialPage.jsx
@@ -233,7 +233,7 @@ const SocialPage = () => {
     try {
       const response = await ChatAPI.getChatParticipations();
 
-      if (response.data.success) {
+      if (response.data.isSuccess) {
         const existingChatroom = response.data.data.chatRooms.find(
           (room) => room.partnerId === targetUserId
         );
@@ -261,7 +261,9 @@ const SocialPage = () => {
       sessionStorage.setItem('partnerId', targetUserId.toString());
     }
 
-    navigate('/chat');
+    setTimeout(() => {
+      navigate('/chat');
+    }, 1000);
   };
 
   const handleBookmarkChange = useCallback(


### PR DESCRIPTION
## ☝️ 요약
채팅페이지 이동 시 세션스토리지에 정보 안 담기는 문제 수정

<br/>

## ✏️ 상세 내용
- 채팅페이지 이동 시 세션스토리지에 partnerId나 chatroomId 정보가 안 담긴 채 이동하는 문제 발생
- 네트워크 탭 확인 결과 chat-participation 요청 200 OK 반환됨
- 콘솔 출력문 확인 결과 신규 채팅방으로 잘 이동됨
- 응답바디가 success -> isSuccess로 수정되어 상대방 정보를 인식할 수 없었던 문제였음. 수정 완료.

<br/>

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Assignee를 지정했습니다.
- [x] 로컬 테스트 완료했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

<br/>

## 🎈 연관된 이슈 (선택)

<br/>

## 비고 (선택)